### PR TITLE
Add integration tests for backend services

### DIFF
--- a/tests/CourseServiceTests.cs
+++ b/tests/CourseServiceTests.cs
@@ -1,0 +1,30 @@
+using saga.Models.DTOs;
+using saga.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading.Tasks;
+
+namespace saga.Tests;
+
+public class CourseServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveCourse()
+    {
+        var logger = new Mock<ILogger<CourseService>>();
+        var service = new CourseService(Repository, logger.Object);
+        var courseDto = new CourseDto
+        {
+            Name = "Algorithms",
+            CourseUnique = "CS101",
+            Credits = 4
+        };
+
+        var created = await service.CreateCourseAsync(courseDto);
+        Assert.NotNull(created.Id);
+
+        var retrieved = await service.GetCourseAsync(created.Id!.Value);
+        Assert.Equal("Algorithms", retrieved.Name);
+        Assert.Equal("CS101", retrieved.CourseUnique);
+    }
+}

--- a/tests/ExtensionServiceTests.cs
+++ b/tests/ExtensionServiceTests.cs
@@ -1,0 +1,47 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class ExtensionServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveExtension()
+    {
+        var user = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "stud2@example.com",
+            Cpf = "22222222222",
+            Role = RolesEnum.Student,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("pwd"),
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var student = await Repository.Student.AddAsync(new StudentEntity
+        {
+            Id = user.Id,
+            UserId = user.Id,
+            Registration = "R2"
+        });
+
+        var logger = new Mock<ILogger<ExtensionService>>();
+        var service = new ExtensionService(Repository, logger.Object);
+        var dto = new ExtensionDto
+        {
+            StudentId = student.Id,
+            NumberOfDays = 15,
+            Type = ExtensionTypeEnum.Defence
+        };
+
+        var created = await service.CreateExtensionAsync(dto);
+        Assert.NotNull(created.Id);
+
+        var retrieved = await service.GetExtensionAsync(created.Id!.Value);
+        Assert.Equal(15, retrieved.NumberOfDays);
+        Assert.Equal(student.Id, retrieved.StudentId);
+    }
+}

--- a/tests/ExternalResearcherServiceTests.cs
+++ b/tests/ExternalResearcherServiceTests.cs
@@ -1,0 +1,43 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using saga.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class ExternalResearcherServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveExternalResearcher()
+    {
+        var userService = new Mock<IUserService>();
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = "ext@example.com",
+            Cpf = "11111111111",
+            Role = RolesEnum.ExternalResearcher,
+            CreatedAt = DateTime.UtcNow
+        };
+        userService.Setup(s => s.CreateUserAsync(It.IsAny<UserDto>()))
+            .ReturnsAsync(user);
+
+        var logger = new Mock<ILogger<ExternalResearcherService>>();
+        var service = new ExternalResearcherService(Repository, logger.Object, userService.Object);
+        var dto = new ExternalResearcherDto
+        {
+            Email = "ext@example.com",
+            Cpf = "11111111111",
+            Role = RolesEnum.ExternalResearcher
+        };
+
+        var created = await service.CreateExternalResearcherAsync(dto);
+        Assert.Equal(user.Id, created.Id);
+
+        var retrieved = await service.GetExternalResearcherAsync(created.Id!.Value);
+        Assert.Equal("ext@example.com", retrieved.Email);
+    }
+}

--- a/tests/GlobalUsings.cs
+++ b/tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/OrientationServiceTests.cs
+++ b/tests/OrientationServiceTests.cs
@@ -1,0 +1,61 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using backend.Infrastructure.Validations;
+using saga.Infrastructure.Providers;
+
+namespace saga.Tests;
+
+public class OrientationServiceTests : TestBase
+{
+    private class DummyUserContext : IUserContext
+    {
+        public Guid? UserId { get; set; }
+        public RolesEnum? Role { get; set; }
+    }
+
+    [Fact]
+    public async Task CreateAndRetrieveOrientation()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var project = await Repository.Project.AddAsync(new ProjectEntity { ResearchLineId = researchLine.Id, Name = "Proj", Status = ProjectStatusEnum.Active });
+
+        var user = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "stu3@example.com",
+            Cpf = "33333333333",
+            Role = RolesEnum.Student,
+            PasswordHash = "hash",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var student = await Repository.Student.AddAsync(new StudentEntity
+        {
+            Id = user.Id,
+            UserId = user.Id,
+            Registration = "R3",
+            ProjectId = project.Id
+        });
+
+        var validations = new Validations(Repository, new Mock<ILogger<UserValidator>>().Object, new DummyUserContext());
+        var logger = new Mock<ILogger<OrientationService>>();
+        var service = new OrientationService(Repository, logger.Object, validations);
+        var dto = new OrientationDto
+        {
+            StudentId = student.Id,
+            ProjectId = project.Id,
+            ProfessorId = Guid.NewGuid(),
+            Dissertation = "Dissertation"
+        };
+
+        var created = await service.CreateOrientationAsync(dto);
+        Assert.NotNull(created.Id);
+
+        var retrieved = await service.GetOrientationAsync(created.Id);
+        Assert.Equal(project.Id, retrieved.ProjectId);
+        Assert.Equal(student.Id, retrieved.StudentId);
+    }
+}

--- a/tests/ProfessorServiceTests.cs
+++ b/tests/ProfessorServiceTests.cs
@@ -1,0 +1,46 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using saga.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class ProfessorServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveProfessor()
+    {
+        var userService = new Mock<IUserService>();
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = "prof@example.com",
+            Cpf = "99999999999",
+            Role = RolesEnum.Professor,
+            CreatedAt = DateTime.UtcNow
+        };
+        userService.Setup(s => s.CreateUserAsync(It.IsAny<UserDto>()))
+            .ReturnsAsync(user);
+
+        var logger = new Mock<ILogger<ProfessorService>>();
+        var service = new ProfessorService(Repository, logger.Object, userService.Object);
+        var dto = new ProfessorDto
+        {
+            Email = "prof@example.com",
+            Cpf = "99999999999",
+            Siape = "12345",
+            Role = RolesEnum.Professor,
+            ProjectIds = new List<string>()
+        };
+
+        var created = await service.CreateProfessorAsync(dto);
+        Assert.Equal(user.Id, created.Id);
+
+        var retrieved = await service.GetProfessorAsync(created.Id!.Value);
+        Assert.Equal("prof@example.com", retrieved.Email);
+        Assert.Equal("12345", retrieved.Siape);
+    }
+}

--- a/tests/ProjectServiceTests.cs
+++ b/tests/ProjectServiceTests.cs
@@ -1,0 +1,33 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class ProjectServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveProject()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var logger = new Mock<ILogger<ProjectService>>();
+        var service = new ProjectService(Repository, logger.Object);
+        var dto = new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectX",
+            Status = ProjectStatusEnum.Active,
+            ProfessorIds = new List<string>()
+        };
+
+        var created = await service.CreateProjectAsync(dto);
+        Assert.NotNull(created.Id);
+
+        var retrieved = await service.GetProjectAsync(created.Id!.Value);
+        Assert.Equal("ProjectX", retrieved.Name);
+        Assert.Equal(researchLine.Id, retrieved.ResearchLineId);
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Integration Tests
+
+This folder contains integration tests for the Saga backend.
+
+Tests run against an in-memory SQLite database. Each test project derives from
+`TestBase`, which configures a `ContexRepository` with an in-memory connection
+and exposes a `Repository` instance used by the services.
+
+Run tests with:
+
+```bash
+dotnet test tests/saga.Tests.csproj
+```
+
+## Services to cover
+
+The backend exposes several services that should be tested through integration
+tests:
+
+- `CourseService`
+- `StudentService`
+- `ProjectService`
+- `ResearchLineService`
+- `ProfessorService`
+- `ExternalResearcherService`
+- `ExtensionService`
+- `OrientationService`
+- `UserService`
+
+Each service provides basic CRUD operations that should be tested using the
+in-memory database setup. Additional validation logic or business rules for each
+service can also be verified using this structure.

--- a/tests/ResearchLineServiceTests.cs
+++ b/tests/ResearchLineServiceTests.cs
@@ -1,0 +1,23 @@
+using saga.Models.DTOs;
+using saga.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class ResearchLineServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveResearchLine()
+    {
+        var logger = new Mock<ILogger<ResearchLineService>>();
+        var service = new ResearchLineService(Repository, logger.Object);
+        var dto = new ResearchLineDto { Name = "Machine Learning" };
+
+        var created = await service.CreateResearchLineAsync(dto);
+        Assert.NotNull(created.Id);
+
+        var retrieved = await service.GetResearchLineAsync(created.Id!.Value);
+        Assert.Equal("Machine Learning", retrieved.Name);
+    }
+}

--- a/tests/StudentServiceTests.cs
+++ b/tests/StudentServiceTests.cs
@@ -1,0 +1,45 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using saga.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class StudentServiceTests : TestBase
+{
+    [Fact]
+    public async Task CreateAndRetrieveStudent()
+    {
+        var userService = new Mock<IUserService>();
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = "student@example.com",
+            Cpf = "12345678901",
+            Role = RolesEnum.Student,
+            CreatedAt = DateTime.UtcNow
+        };
+        userService.Setup(s => s.CreateUserAsync(It.IsAny<UserDto>()))
+            .ReturnsAsync(user);
+
+        var logger = new Mock<ILogger<StudentService>>();
+        var service = new StudentService(Repository, logger.Object, userService.Object);
+        var dto = new StudentDto
+        {
+            Email = "student@example.com",
+            Cpf = "12345678901",
+            Registration = "2023",
+            Role = RolesEnum.Student
+        };
+
+        var created = await service.CreateStudentAsync(dto);
+        Assert.Equal(user.Id, created.Id);
+
+        var retrieved = await service.GetStudentAsync(created.Id!.Value);
+        Assert.Equal("2023", retrieved.Registration);
+        Assert.Equal("student@example.com", retrieved.Email);
+    }
+}

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using saga.Infrastructure.Providers;
+using saga.Infrastructure.Repositories;
+using saga.Models.Enums;
+
+namespace saga.Tests;
+
+public abstract class TestBase : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    protected ContexRepository Context { get; }
+    protected Repository Repository { get; }
+
+    protected TestBase()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<ContexRepository>()
+            .UseSqlite(_connection)
+            .Options;
+
+        var userContext = new FakeUserContext();
+        Context = new ContexRepository(options);
+        Context.Database.EnsureCreated();
+        Repository = new Repository(Context, userContext);
+    }
+
+    public void Dispose()
+    {
+        Context.Dispose();
+        _connection.Close();
+    }
+
+    private class FakeUserContext : IUserContext
+    {
+        public Guid? UserId { get; set; }
+        public RolesEnum? Role { get; set; }
+    }
+}

--- a/tests/UserServiceTests.cs
+++ b/tests/UserServiceTests.cs
@@ -1,0 +1,48 @@
+using saga.Models.DTOs;
+using saga.Models.Entities;
+using saga.Models.Enums;
+using saga.Services;
+using saga.Infrastructure.Providers;
+using backend.Infrastructure.Validations;
+using saga.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace saga.Tests;
+
+public class UserServiceTests : TestBase
+{
+    private class DummyUserContext : IUserContext
+    {
+        public Guid? UserId { get; set; }
+        public RolesEnum? Role { get; set; }
+    }
+
+    [Fact]
+    public async Task AuthenticateUser()
+    {
+        var password = "secret";
+        var hashed = BCrypt.Net.BCrypt.HashPassword(password);
+        var user = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "auth@example.com",
+            Cpf = "44444444444",
+            PasswordHash = hashed,
+            Role = RolesEnum.Student,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(t => t.GenerateJwtToken(It.IsAny<UserEntity>())).Returns("token");
+        var emailSender = new Mock<IEmailSender>();
+        var validations = new Validations(Repository, new Mock<ILogger<UserValidator>>().Object, new DummyUserContext());
+        var logger = new Mock<ILogger<UserService>>();
+        var userContext = new DummyUserContext();
+        var service = new UserService(Repository, tokenProvider.Object, logger.Object, emailSender.Object, validations, userContext);
+
+        var result = await service.AuthenticateAsync(new LoginDto { Email = user.Email, Password = password });
+
+        Assert.Equal("token", result.Token);
+        Assert.Equal(user.Email, result.User!.Email);
+    }
+}

--- a/tests/saga.Tests.csproj
+++ b/tests/saga.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../backend/saga.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- extend test project with Moq dependency
- update existing course test to use mocked logger
- add integration tests for Student, Project, ResearchLine, Professor, ExternalResearcher, Extension, Orientation and User services

## Testing
- `dotnet test tests/saga.Tests.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68471e3c337c8331b673a2b7ab6ee24d