### PR TITLE
Implement profile pages and edit options

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -18,7 +18,11 @@ import CsvLoader from './pages/CsvLoader';
 import StudentUpdate from './pages/student/studentUpdate';
 import ResearcherUpdate from './pages/researcher/researcherUpdate';
 import ProfessorUpdate from './pages/professor/professorUpdate';
+import ProfessorProfile from './pages/professor/profile';
 import StudentForm from './pages/student/CreateStudent';
+import ProjectProfile from './pages/projects/profile';
+import ResearchUpdate from './pages/research/updateResearch';
+import ExtensionUpdate from './pages/extension/updateExtension';
 
 export default function App() {
   return (
@@ -41,11 +45,15 @@ export default function App() {
         <Route path="/students/add" element={<StudentForm />} />
         <Route path="/professors/add" element={<UserForm type={"Professor"}/>} />
         <Route path="/researches/add" element={<UserForm type={"Externo"}/>} />
-        <Route path="/professors/:id" element={<ProfessorUpdate/>} />
+        <Route path="/professors/:id" element={<ProfessorProfile/>} />
+        <Route path="/professors/:id/edit" element={<ProfessorUpdate/>} />
         <Route path="/researchers/:id" element={<ResearcherUpdate />} />
         <Route path="/projects/add" element={<ProjectForm />} />
-        <Route path="/projects/:id" element={<ProjectForm Update={true} />} />
+        <Route path="/projects/:id" element={<ProjectProfile />} />
+        <Route path="/projects/:id/edit" element={<ProjectForm Update={true} />} />
         <Route path="/students/:id/extensions/add" element={<ExtensionForm />} />
+        <Route path="/researches/:id/edit" element={<ResearchUpdate />} />
+        <Route path="/extensions/:id/edit" element={<ExtensionUpdate />} />
       </Routes>
     </Router>
   );

--- a/front/src/api/extension_service.js
+++ b/front/src/api/extension_service.js
@@ -11,3 +11,11 @@ export async function postExtensions(data) {
 export async function deleteExtensions(id) {
     return await api.delete(`extensions/${id}`)
 }
+
+export async function getExtensionById(id){
+    return (await api.get(`extensions/${id}`))?.data
+}
+
+export async function putExtensionById(id, data){
+    return (await api.put(`extensions/${id}`, data))?.data
+}

--- a/front/src/api/research_service.js
+++ b/front/src/api/research_service.js
@@ -7,3 +7,11 @@ export async function getResearch(){
 export async function postResearch(data){
     return (await api.post("orientations",data))?.data
 }
+
+export async function getResearchById(id){
+    return (await api.get(`orientations/${id}`))?.data
+}
+
+export async function putResearch(id, data){
+    return (await api.put(`orientations/${id}`, data))?.data
+}

--- a/front/src/enum_helpers.js
+++ b/front/src/enum_helpers.js
@@ -1,10 +1,10 @@
 export const AREA_ENUM = [
     { key: 0, name: "Default", translation: "Padrão" },
-    { key: 1, name: "COMPUTATION", translation: "Computação" },
-    { key: 2, name: "EXACT_SCIENCES", translation: "Ciências Exatas" },
-    { key: 3, name: "HUMANITIES", translation: "Humanidades" },
-    { key: 4, name: "HEALTH", translation: "Saúde" },
-    { key: 5, name: "ENGINEERING", translation: "Engenharia" },
+    { key: 1, name: "COMPUTATION", translation: "COMPUTAÇÃO" },
+    { key: 2, name: "EXACT_SCIENCES", translation: "EXATAS" },
+    { key: 3, name: "HUMANITIES", translation: "HUMANAS" },
+    { key: 4, name: "HEALTH", translation: "BIOLÓGICA" },
+    { key: 5, name: "ENGINEERING", translation: "ENGENHARIA" },
   ];
   
   export const STATUS_ENUM = [
@@ -32,16 +32,16 @@ export const AREA_ENUM = [
   
   export const INSTITUTION_TYPE_ENUM = [
     { key: 0, name: "Default", translation: "Padrão" },
-    { key: 1, name: "Publica", translation: "Pública" },
-    { key: 2, name: "Particular", translation: "Particular" },
-    { key: 3, name: "CEFET", translation: "CEFET" },
+    { key: 1, name: "Publica", translation: "PÚBLICA" },
+    { key: 2, name: "Particular", translation: "PARTICULAR" },
+    { key: 3, name: "CEFET", translation: "CEFET/RJ" },
   ];
   
   export const SCHOLARSHIP_TYPE = [
-    { key: 0, name: "Default", translation: "Padrão" },
-    { key: 1, name: "Cefet", translation: "Cefet" },
-    { key: 2, name: "Capes", translation: "Capes" },
-    { key: 3, name: "FapeRj", translation: "FapeRj" },
+    { key: 0, name: "Default", translation: "SEM BOLSA" },
+    { key: 1, name: "Cefet", translation: "CEFET/RJ" },
+    { key: 2, name: "Capes", translation: "CAPES" },
+    { key: 3, name: "FapeRj", translation: "FAPERJ" },
   ];
 
   export const translateEnumValue = (enumValues, value) => {

--- a/front/src/pages/extension/extensionList.jsx
+++ b/front/src/pages/extension/extensionList.jsx
@@ -70,7 +70,7 @@ export default function ExtensionList() {
                     </div>
                 </div>
                 <BackButton />
-                <Table data={extensions} useOptions={false} />
+                <Table data={extensions} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
                 {error && < ErrorPage/>}
     </PageContainer>)
 }

--- a/front/src/pages/extension/updateExtension.jsx
+++ b/front/src/pages/extension/updateExtension.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import "../../styles/createExtension.scss";
+import { useParams, useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import Select from "../../components/select";
+import BackButton from "../../components/BackButton";
+import PageContainer from "../../components/PageContainer";
+import ErrorPage from "../../components/error/Error";
+import { getExtensionById, putExtensionById } from "../../api/extension_service";
+
+export default function ExtensionUpdate(){
+    const navigate = useNavigate();
+    const { id } = useParams();
+    const [name] = useState(localStorage.getItem('name'));
+    const [role, setRole] = useState(localStorage.getItem('role'));
+    const [extension, setExtension] = useState();
+    const [error, setError] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(()=>{
+        const token = localStorage.getItem('token');
+        try{
+            const decoded = jwt_decode(token);
+            setRole(decoded.role);
+        }catch(err){
+            navigate('/login');
+        }
+    },[navigate]);
+
+    useEffect(()=>{
+        getExtensionById(id)
+            .then(res => { setExtension(res); setIsLoading(false); })
+            .catch(()=>{ setError(true); setIsLoading(false); });
+    }, [id]);
+
+    const setDays = (val)=> setExtension({...extension, numberOfDays: Number(val)});
+    const setType = (val)=> setExtension({...extension, type: val === 'Defesa' ? 1:2});
+
+    const handleUpdate=(e)=>{
+        e.preventDefault();
+        putExtensionById(id, extension)
+            .then(()=>navigate(-1))
+            .catch(()=>setError(true));
+    };
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            <BackButton />
+            {!error && extension && (
+                <div className='extensionForm'>
+                    <div className='form-section'>
+                        <div className='formInput'>
+                            <label htmlFor='numberOfDays'>Quantidade de Dias</label>
+                            <input type='number' name='numberOfDays' value={extension.numberOfDays} onChange={e=>setDays(e.target.value)} id='numberOfDays'/>
+                        </div>
+                        <Select
+                            className='formInput'
+                            onSelect={setType}
+                            defaultValue={extension.type === 1 ? 'Defesa':'Qualificação'}
+                            options={["Defesa","Qualificação"].map(o=>({value:o,label:o}))}
+                            label='Type'
+                            name='type'
+                        />
+                    </div>
+                    <div className='form-section'>
+                        <div className='formInput'>
+                            <input type='submit' value='Update' onClick={handleUpdate}/>
+                        </div>
+                    </div>
+                </div>
+            )}
+            {error && <ErrorPage />}
+        </PageContainer>
+    );
+}

--- a/front/src/pages/professor/profile.jsx
+++ b/front/src/pages/professor/profile.jsx
@@ -1,0 +1,59 @@
+import { useParams, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import "../../styles/profile.scss";
+import PageContainer from "../../components/PageContainer";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import jwt_decode from "jwt-decode";
+import { getProfessorById } from "../../api/professor_service";
+
+export default function ProfessorProfile(){
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [professor, setProfessor] = useState();
+    const [error, setError] = useState(false);
+    const [role, setRole] = useState();
+    const [isLoading, setIsLoading] = useState(true);
+    const [name] = useState(localStorage.getItem('name'));
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            setRole(decoded.role);
+        } catch(err){
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getProfessorById(id)
+            .then(result => { setProfessor(result); setIsLoading(false); })
+            .catch(() => { setError(true); setIsLoading(false); });
+    }, [id]);
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            {!error && professor && (
+                <div style={{display:'flex', flexDirection:'column', flexWrap:'wrap'}}>
+                    <div className="bar">
+                        <BackButton />
+                        {role === 'Administrator' && (
+                            <div className="options">
+                                <input type={'button'} className="option" value={'Editar Professor'} onClick={()=>navigate('edit')} />
+                            </div>
+                        )}
+                    </div>
+                    <div className="card-label">Perfil professor</div>
+                    <div className="studentCard">
+                        <p data-label="Nome">{`${professor.firstName} ${professor.lastName}`}</p>
+                        <p data-label="Email">{professor.email}</p>
+                        <p data-label="CPF">{professor.cpf}</p>
+                        <p data-label="SIAPE">{professor.siape}</p>
+                    </div>
+                </div>
+            )}
+            {error && <ErrorPage />}
+        </PageContainer>
+    );
+}

--- a/front/src/pages/projects/createProject.jsx
+++ b/front/src/pages/projects/createProject.jsx
@@ -175,7 +175,7 @@ export default function ProjectForm({ Update = false }) {
           </div>
           <div className="form-section">
             <div className="formInput">
-              <input type="submit" value="Submit" onClick={(e) => handleSave(e)} />
+              <input type="submit" value={isUpdate ? "Update" : "Submit"} onClick={(e) => handleSave(e)} />
             </div>
           </div>
         </form>

--- a/front/src/pages/projects/profile.jsx
+++ b/front/src/pages/projects/profile.jsx
@@ -1,0 +1,60 @@
+import { useParams, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import "../../styles/profile.scss";
+import PageContainer from "../../components/PageContainer";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import jwt_decode from "jwt-decode";
+import { getProjectById } from "../../api/project_service";
+import { translateEnumValue, PROJECT_STATUS_ENUM } from "../../enum_helpers";
+
+export default function ProjectProfile(){
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [project, setProject] = useState();
+    const [role, setRole] = useState();
+    const [error, setError] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [name] = useState(localStorage.getItem('name'));
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            setRole(decoded.role);
+        } catch(err){
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getProjectById(id)
+            .then(res => { setProject(res); setIsLoading(false); })
+            .catch(()=> { setError(true); setIsLoading(false); });
+    }, [id]);
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            {!error && project && (
+                <div style={{display:'flex', flexDirection:'column', flexWrap:'wrap'}}>
+                    <div className="bar">
+                        <BackButton />
+                        {role === 'Administrator' && (
+                            <div className="options">
+                                <input type='button' className='option' value='Editar Projeto' onClick={()=>navigate('edit')} />
+                            </div>
+                        )}
+                    </div>
+                    <div className="card-label">Perfil projeto</div>
+                    <div className="studentCard">
+                        <p data-label="Nome">{project.name}</p>
+                        <p data-label="Status">{translateEnumValue(PROJECT_STATUS_ENUM, project.status)}</p>
+                        <p data-label="Professores">{project.professors?.map(p => `${p.firstName} ${p.lastName}`).join(', ')}</p>
+                        <p data-label="Estudantes">{project.students?.length}</p>
+                    </div>
+                </div>
+            )}
+            {error && <ErrorPage />}
+        </PageContainer>
+    );
+}

--- a/front/src/pages/research/researchList.jsx
+++ b/front/src/pages/research/researchList.jsx
@@ -40,8 +40,9 @@ export default function ResearchList() {
             return {
               Id: research.id,
               Nome: research.dissertation,
-              Professores: `${research.professor?.firstName} ${research.professor?.lastName}`,
-              Students: `${research.student?.firstName} ${research.student?.lastName}`,
+              Orientador: `${research.professor?.firstName} ${research.professor?.lastName}`,
+              Coorientador: research.coorientator ? `${research.coorientator?.firstName} ${research.coorientator?.lastName}` : '',
+              Estudante: `${research.student?.firstName} ${research.student?.lastName}`,
             };
           });
         }
@@ -72,7 +73,7 @@ export default function ResearchList() {
             </div>
           </div>
           <BackButton />
-          <Table data={researches} />
+          <Table data={researches} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
         </>
       ) : (
         <ErrorPage />

--- a/front/src/pages/researcher/researcherList.jsx
+++ b/front/src/pages/researcher/researcherList.jsx
@@ -67,7 +67,7 @@ export default function ResearcherList() {
                 </div>
             </div>
             <BackButton />
-            <Table data={researchers} />
+            <Table data={researchers} useOptions={true} detailsCallback={(id)=>navigate(`${id}`)} />
         </PageContainer>
     )
 }

--- a/front/src/pages/student/StudentList.jsx
+++ b/front/src/pages/student/StudentList.jsx
@@ -9,6 +9,9 @@ import PageContainer from "../../components/PageContainer"
 import { translateEnumValue } from "../../enum_helpers";
 import { STATUS_ENUM } from "../../enum_helpers";
 
+const formatDate = (date) =>
+  date ? new Date(date).toISOString().split("T")[0] : "";
+
 export default function StudentList() {
     const navigate = useNavigate()
     const [name, _] = useState(localStorage.getItem('name'))
@@ -35,18 +38,15 @@ export default function StudentList() {
             .then(result => {
                 let mapped = []
                 if (result !== null && result !== undefined) {
-                    console.log(result)
-                    mapped = result.map((student) => {
-                        return {
-                            Id: student.id,
-                            Nome: `${student.firstName} ${student.lastName}`,
-                            Status: translateEnumValue(STATUS_ENUM, student.status),
-                            "E-mail": student.email,
-                            "Matrícula": student.registration,
-                            "Data de defesa": student.projectDefenceDate,
-                            "Data de qualificação": student.projectQualificationDate
-                        }
-                    })
+                    mapped = result.map((student) => ({
+                        Id: student.id,
+                        Nome: `${student.firstName} ${student.lastName}`,
+                        Status: translateEnumValue(STATUS_ENUM, student.status),
+                        "E-mail": student.email,
+                        "Matrícula": student.registration,
+                        "Data de qualificação": formatDate(student.projectQualificationDate),
+                        "Data de defesa": formatDate(student.projectDefenceDate),
+                    }))
                 }
                 setStudents(mapped)
                 setIsLoading(false)

--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -12,6 +12,7 @@ import PageContainer from "../../components/PageContainer";
 import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE } from "../../enum_helpers";
 import MultiSelect from "../../components/Multiselect";
 import { translateEnumValue } from "../../enum_helpers";
+import { isValidCPF } from "../../utils/cpf";
 
 
 export default function UserForm({ type = undefined, isUpdate = false }) {
@@ -230,6 +231,11 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
     const handleSave = (e) => {
         e.preventDefault();
         const form = document.querySelector('form');
+        if (!isValidCPF(user.cpf)) {
+            setError(true);
+            setErrorMessage('CPF inválido');
+            return;
+        }
         if (form.reportValidity()) {
             isUpdate ? handleUpdate() : handlepost();
         }
@@ -296,7 +302,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             </div>
                             <div className="formInput">
                                 <label htmlFor="cpf">CPF</label>
-                                <input required={true} disabled={isUpdate} type="text" name="cpf" value={user.cpf} id="cpf" onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
+                                <input required={true} type="text" name="cpf" value={user.cpf} id="cpf" onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
                             </div>
                         </div>
                         {userType === "Estudante" && (
@@ -304,7 +310,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                                 <div className="form-section" id="registration-section">
                                     <div className="formInput">
                                         <label htmlFor="registration">Matricula</label>
-                                        <input required={true} disabled={isUpdate} type="text" name="registration" id="registration" value={student.registration} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                        <input required={true} type="text" name="registration" id="registration" value={student.registration} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
                                     </div>
                                     <div className="formInput">
                                         <Select
@@ -318,19 +324,19 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                                     </div>
                                     <div className="formInput">
                                         <label htmlFor="registrationDate">Data de Matrícula</label>
-                                        <input required={true} disabled={isUpdate} type="date" name="registrationDate" id="registrationDate" value={student.registrationDate} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                        <input required={true} type="date" name="registrationDate" id="registrationDate" value={student.registrationDate} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
                                     </div>
                                     <div className="formInput">
                                         <label htmlFor="entryDate">Data de Entrada</label>
-                                        <input required={true} disabled={isUpdate} type="date" name="entryDate" id="entryDate" value={student.entryDate} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                        <input required={true} type="date" name="entryDate" id="entryDate" value={student.entryDate} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
                                     </div>
                                     <div className="formInput">
                                         <label htmlFor="dateOfBirth">Data de Nascimento</label>
-                                        <input required={true} disabled={isUpdate} type="date" name="dateOfBirth" id="dateOfBirth" value={student.dateOfBirth} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                        <input required={true} type="date" name="dateOfBirth" id="dateOfBirth" value={student.dateOfBirth} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
                                     </div>
                                     <div className="form-section" id="qualification-section2">
                                         <div className="formInput">
-                                            <label htmlFor="undergraduateInstitution">Institução de graduação</label>
+                                            <label htmlFor="undergraduateInstitution">Instituição de Graduação</label>
                                             <input required={true} minLength={3} type="text" name="undergraduateInstitution" value={student.undergraduateInstitution} id="undergraduateInstitution" onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
                                         </div>
                                         <div className="formInput">
@@ -384,7 +390,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             {userType === "Professor" && (
                                 <div className="formInput">
                                     <label htmlFor="siape">SIAPE</label>
-                                    <input required={userType === "Professor"} disabled={isUpdate} type="text" minLength={3} value={professor.siape} name="siape" id="siape" onChange={(e) => changeProfessorAtribute(e.target.name, e.target.value)} />
+                                    <input required={userType === "Professor"} type="text" minLength={3} value={professor.siape} name="siape" id="siape" onChange={(e) => changeProfessorAtribute(e.target.name, e.target.value)} />
                                 </div>
                             )}
                             {userType === "Externo" && (

--- a/front/src/styles/createResearch.scss
+++ b/front/src/styles/createResearch.scss
@@ -82,4 +82,9 @@
             }
     }
     }
+
+.success {
+    color: green;
+    margin: 1rem;
+}
 }

--- a/front/src/utils/cpf.js
+++ b/front/src/utils/cpf.js
@@ -1,0 +1,16 @@
+export function isValidCPF(cpf) {
+  if (!cpf) return false;
+  cpf = cpf.replace(/[^\d]+/g, "");
+  if (cpf.length !== 11) return false;
+  if (/^(\d)\1+$/.test(cpf)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += parseInt(cpf.charAt(i)) * (10 - i);
+  let rev = 11 - (sum % 11);
+  if (rev === 10 || rev === 11) rev = 0;
+  if (rev !== parseInt(cpf.charAt(9))) return false;
+  sum = 0;
+  for (let i = 0; i < 10; i++) sum += parseInt(cpf.charAt(i)) * (11 - i);
+  rev = 11 - (sum % 11);
+  if (rev === 10 || rev === 11) rev = 0;
+  return rev === parseInt(cpf.charAt(10));
+}


### PR DESCRIPTION
## Summary
- add API helpers for updating orientations and extensions
- create profile pages for professors and projects
- enable editing for researchers, dissertations, extensions and projects
- show coorientator in dissertation list and fix update buttons
- allow editing professor SIAPE

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684726e6ca408331aa73da781ea475ae