### PR TITLE
Add user list and admin user controls

### DIFF
--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -59,5 +59,36 @@ namespace saga.Controllers
                 return BadRequest(ex.Message);
             }
         }
+
+        [HttpGet]
+        [Authorize(Roles = "Administrator")]
+        [ProducesResponseType(typeof(IEnumerable<UserDto>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<UserDto>>> GetUsers()
+        {
+            try
+            {
+                var users = await _userService.GetAllUsersAsync();
+                return Ok(users);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteUser(Guid id)
+        {
+            try
+            {
+                await _userService.DeleteUserAsync(id);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
     }
 }

--- a/backend/Services/Interfaces/IUserService.cs
+++ b/backend/Services/Interfaces/IUserService.cs
@@ -38,5 +38,17 @@ namespace saga.Services.Interfaces
         /// <returns>A task representing the asynchronous password reset operation.</returns>
         /// <exception cref="ArgumentException">Thrown when the user with the specified email is not found.</exception>
         Task<LoginResultDto> ResetPasswordAsync(ResetPasswordDto loginDto);
+
+        /// <summary>
+        /// Retrieves all users registered in the system.
+        /// </summary>
+        /// <returns>A collection of users.</returns>
+        Task<IEnumerable<UserDto>> GetAllUsersAsync();
+
+        /// <summary>
+        /// Removes a user by its identifier.
+        /// </summary>
+        /// <param name="id">User identifier.</param>
+        Task DeleteUserAsync(Guid id);
     }
 }

--- a/backend/Services/UserService.cs
+++ b/backend/Services/UserService.cs
@@ -9,6 +9,7 @@ using saga.Models.Entities;
 using saga.Models.Mapper;
 using saga.Properties;
 using saga.Services.Interfaces;
+using System.Linq;
 
 namespace saga.Services
 {
@@ -102,6 +103,19 @@ namespace saga.Services
             }
 
             return user.ToDto(_tokenProvider.GenerateJwtToken(user));
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<UserDto>> GetAllUsersAsync()
+        {
+            var users = await _repository.User.GetAllAsync();
+            return users.Select(u => u.ToUserDto());
+        }
+
+        /// <inheritdoc />
+        public async Task DeleteUserAsync(Guid id)
+        {
+            await _repository.User.DeactiveByIdAsync(id);
         }
 
         private string HashPassword(string password)

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -5,6 +5,8 @@ import Login from "./pages/login";
 import ResetPassword from "./pages/changePassword";
 import StudentProfile from "./pages/student/profile";
 import UserForm from './pages/user/createUser';
+import UserList from './pages/user/userList';
+import UserUpdate from './pages/user/userUpdate';
 import StudentList from './pages/student/StudentList';
 import ProfessorList from './pages/professor/professorList';
 import ResearcherList from './pages/researcher/researcherList';
@@ -39,6 +41,8 @@ export default function App() {
         <Route path="/researches" element={<ResearchList />} />
         <Route path="/extensions" element={<ExtensionList />} />
         <Route path="/projects" element={<ProjectList />} />
+        <Route path="/users" element={<UserList />} />
+        <Route path="/users/:role/:id/edit" element={<UserUpdate />} />
         <Route path="/user/add" element={<UserForm />} />
         <Route path="/entities/csv" element={<CsvLoader />} />
         <Route path="/students/:id/researches/add" element={<ResearchForm />} />

--- a/front/src/api/user_service.js
+++ b/front/src/api/user_service.js
@@ -17,8 +17,16 @@ export function Login({email, password})
         return api.postWithoutToken('users/resetPassword', { password }, config)
     }
 
-    export function ForgotPassword({email, resetPasswordPath})
-    {
-        return api.postWithoutToken('users/resetPasswordRequet', { email, resetPasswordPath })
-    }
+export function ForgotPassword({email, resetPasswordPath})
+{
+    return api.postWithoutToken('users/resetPasswordRequet', { email, resetPasswordPath })
+}
+
+export async function getUsers(){
+    return (await api.get('users'))?.data
+}
+
+export async function deleteUser(id){
+    return (await api.delete(`users/${id}`))?.data
+}
 

--- a/front/src/pages/user/userList.jsx
+++ b/front/src/pages/user/userList.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import '../../styles/userList.scss';
+import Table from "../../components/Table/table";
+import { getUsers, deleteUser } from "../../api/user_service";
+import { useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import PageContainer from "../../components/PageContainer";
+import { translateEnumValue, ROLES_ENUM } from "../../enum_helpers";
+
+export default function UserList() {
+    const navigate = useNavigate();
+    const [name] = useState(localStorage.getItem('name'));
+    const [role, setRole] = useState(localStorage.getItem('role'));
+    const [users, setUsers] = useState([]);
+    const [tableData, setTableData] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            if (decoded.role !== 'Administrator') {
+                navigate('/');
+            }
+            setRole(decoded.role);
+        } catch (error) {
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getUsers()
+            .then(result => {
+                const list = result ?? [];
+                setUsers(list);
+                const mapped = list.map(u => ({
+                    Id: u.id,
+                    Nome: `${u.firstName} ${u.lastName}`,
+                    Email: u.email,
+                    Perfil: translateEnumValue(ROLES_ENUM, u.role)
+                }));
+                setTableData(mapped);
+                setIsLoading(false);
+            });
+    }, []);
+
+    const handleDelete = (id) => {
+        deleteUser(id).then(() => {
+            setUsers(users.filter(u => u.id !== id));
+            setTableData(tableData.filter(t => t.Id !== id));
+        });
+    };
+
+    const handleDetails = (id) => {
+        const user = users.find(u => u.id === id);
+        if (!user) return;
+        switch (user.role) {
+            case 'Student':
+                navigate(`/students/${id}/edit`);
+                break;
+            case 'Professor':
+                navigate(`/professors/${id}/edit`);
+                break;
+            case 'ExternalResearcher':
+                navigate(`/researchers/${id}`);
+                break;
+            default:
+                break;
+        }
+    };
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            <div className="userBar">
+                <div className="left-bar">
+                    <div>
+                        <img src="student.png" alt="Users" height={"100rem"} />
+                    </div>
+                    <div className="title">Usuários</div>
+                </div>
+                <div className="right-bar">
+                    <div className="search">
+                        <input type="search" name="search" id="search" />
+                    </div>
+                    <div className="create-button">
+                        <button onClick={() => navigate('/user/add')}>Novo Usuário</button>
+                    </div>
+                </div>
+            </div>
+            <BackButton />
+            <Table data={tableData} useOptions={true} detailsCallback={handleDetails} deleteCallback={handleDelete} />
+        </PageContainer>
+    );
+}

--- a/front/src/pages/user/userUpdate.jsx
+++ b/front/src/pages/user/userUpdate.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import UserForm from './createUser';
+
+export default function UserUpdate(){
+    const { role } = useParams();
+    return <UserForm isUpdate={true} type={role} />;
+}

--- a/front/src/styles/userList.scss
+++ b/front/src/styles/userList.scss
@@ -1,0 +1,48 @@
+.userBar {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .left-bar {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        flex-direction: row;
+
+        .title {
+            text-align: center;
+            font-size: xx-large;
+            font-weight: bolder;
+        }
+    }
+
+    .right-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        align-items: center;
+        flex-direction: row;
+        padding: 1rem;
+
+        button {
+            border-radius: 2rem;
+            padding: 1rem;
+            color: white;
+            margin: 0.5rem;
+            font-weight: bold;
+            background: #004AAD;
+        }
+
+        input {
+            visibility: hidden;
+            border-radius: 1rem;
+            text-align: center;
+            padding: 0.5rem;
+            color: #004AAD;
+            border: 2px solid #004AAD;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement user listing and deletion endpoints
- expose API for fetching/removing users
- add admin-only user list page with edit and delete options
- add corresponding routes

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a143ca0c833180a4a4bee9d744a8