### PR TITLE
Implement researcher profile and routing

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -8,6 +8,7 @@ import UserForm from './pages/user/createUser';
 import StudentList from './pages/student/StudentList';
 import ProfessorList from './pages/professor/professorList';
 import ResearcherList from './pages/researcher/researcherList';
+import ResearcherProfile from './pages/researcher/profile';
 import ProjectList from './pages/projects/projectList';
 import ProjectForm from './pages/projects/createProject';
 import ExtensionList from './pages/extension/extensionList';
@@ -47,7 +48,8 @@ export default function App() {
         <Route path="/researches/add" element={<UserForm type={"Externo"}/>} />
         <Route path="/professors/:id" element={<ProfessorProfile/>} />
         <Route path="/professors/:id/edit" element={<ProfessorUpdate/>} />
-        <Route path="/researchers/:id" element={<ResearcherUpdate />} />
+        <Route path="/researchers/:id" element={<ResearcherProfile />} />
+        <Route path="/researchers/:id/edit" element={<ResearcherUpdate />} />
         <Route path="/projects/add" element={<ProjectForm />} />
         <Route path="/projects/:id" element={<ProjectProfile />} />
         <Route path="/projects/:id/edit" element={<ProjectForm Update={true} />} />

--- a/front/src/pages/researcher/profile.jsx
+++ b/front/src/pages/researcher/profile.jsx
@@ -1,0 +1,59 @@
+import { useParams, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import "../../styles/profile.scss";
+import PageContainer from "../../components/PageContainer";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import jwt_decode from "jwt-decode";
+import { getResearcherById } from "../../api/researcher_service";
+
+export default function ResearcherProfile(){
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [researcher, setResearcher] = useState();
+    const [error, setError] = useState(false);
+    const [role, setRole] = useState();
+    const [isLoading, setIsLoading] = useState(true);
+    const [name] = useState(localStorage.getItem('name'));
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            setRole(decoded.role);
+        } catch(err){
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getResearcherById(id)
+            .then(res => { setResearcher(res); setIsLoading(false); })
+            .catch(()=> { setError(true); setIsLoading(false); });
+    }, [id]);
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            {!error && researcher && (
+                <div style={{display:'flex', flexDirection:'column', flexWrap:'wrap'}}>
+                    <div className="bar">
+                        <BackButton />
+                        {role === 'Administrator' && (
+                            <div className="options">
+                                <input type='button' className='option' value='Editar Pesquisador' onClick={()=>navigate('edit')} />
+                            </div>
+                        )}
+                    </div>
+                    <div className="card-label">Perfil pesquisador</div>
+                    <div className="studentCard">
+                        <p data-label="Nome">{`${researcher.firstName} ${researcher.lastName}`}</p>
+                        <p data-label="Email">{researcher.email}</p>
+                        <p data-label="CPF">{researcher.cpf}</p>
+                        <p data-label="Instituição">{researcher.institution}</p>
+                    </div>
+                </div>
+            )}
+            {error && <ErrorPage />}
+        </PageContainer>
+    );
+}

--- a/front/src/pages/researcher/researcherList.jsx
+++ b/front/src/pages/researcher/researcherList.jsx
@@ -14,6 +14,10 @@ export default function ResearcherList() {
     const [isLoading, setIsLoading] = useState(true)
     const [researchers, setResearchers] = useState([])
 
+    const detailsCallback = (id) => {
+        navigate(id)
+    }
+
     useEffect(() => {
         const roles = ['Administrator']
         const token = localStorage.getItem('token')
@@ -67,7 +71,7 @@ export default function ResearcherList() {
                 </div>
             </div>
             <BackButton />
-            <Table data={researchers} useOptions={true} detailsCallback={(id)=>navigate(`${id}`)} />
+            <Table data={researchers} useOptions={true} detailsCallback={detailsCallback} />
         </PageContainer>
     )
 }


### PR DESCRIPTION
## Summary
- add researcher profile page
- route researchers by id to profile and editing
- adjust researcher list to open profile

## Testing
- `npm install` *(fails: react-scripts not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a1733b848331b54327f5ca77a687