### PR TITLE
Add research line management pages

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -23,6 +23,9 @@ import StudentForm from './pages/student/CreateStudent';
 import ProjectProfile from './pages/projects/profile';
 import ResearchUpdate from './pages/research/updateResearch';
 import ExtensionUpdate from './pages/extension/updateExtension';
+import ResearchLineList from './pages/researchLine/researchLineList';
+import CreateResearchLine from './pages/researchLine/createResearchLine';
+import UpdateResearchLine from './pages/researchLine/updateResearchLine';
 
 export default function App() {
   return (
@@ -54,6 +57,9 @@ export default function App() {
         <Route path="/students/:id/extensions/add" element={<ExtensionForm />} />
         <Route path="/researches/:id/edit" element={<ResearchUpdate />} />
         <Route path="/extensions/:id/edit" element={<ExtensionUpdate />} />
+        <Route path="/researchLines" element={<ResearchLineList />} />
+        <Route path="/researchLines/add" element={<CreateResearchLine />} />
+        <Route path="/researchLines/:id/edit" element={<UpdateResearchLine />} />
       </Routes>
     </Router>
   );

--- a/front/src/api/research_line.js
+++ b/front/src/api/research_line.js
@@ -3,3 +3,15 @@ import api from './_api'
 export async function getResearchLines(){
     return (await api.get("researchLines"))?.data
 }
+
+export async function postResearchLine(data){
+    return (await api.post("researchLines", data))?.data
+}
+
+export async function putResearchLine(id, data){
+    return (await api.put(`researchLines/${id}`, data))?.data
+}
+
+export async function deleteResearchLine(id){
+    return await api.delete(`researchLines/${id}`)
+}

--- a/front/src/pages/researchLine/createResearchLine.jsx
+++ b/front/src/pages/researchLine/createResearchLine.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import "../../styles/form.scss";
+import { useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import PageContainer from "../../components/PageContainer";
+import { postResearchLine } from "../../api/research_line";
+
+export default function CreateResearchLine() {
+  const navigate = useNavigate();
+  const [name] = useState(localStorage.getItem("name"));
+  const [role, setRole] = useState(localStorage.getItem("role"));
+  const [line, setLine] = useState({ name: "" });
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const roles = ["Administrator"];
+    const token = localStorage.getItem("token");
+    try {
+      const decoded = jwt_decode(token);
+      if (!roles.includes(decoded.role)) {
+        navigate("/");
+      }
+      setRole(decoded.role);
+    } catch (error) {
+      navigate("/login");
+    }
+  }, [setRole, navigate, role]);
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    postResearchLine(line)
+      .then(() => navigate(-1))
+      .catch(() => setError(true));
+  };
+
+  return (
+    <PageContainer name={name} isLoading={false}>
+      <BackButton />
+      {!error ? (
+        <form className="form">
+          <div className="form-section">
+            <div className="formInput">
+              <label htmlFor="name">Nome</label>
+              <input
+                required
+                type="text"
+                name="name"
+                value={line.name}
+                onChange={(e) => setLine({ name: e.target.value })}
+                id="name"
+              />
+            </div>
+          </div>
+          <div className="form-section">
+            <div className="formInput">
+              <input type="submit" value={"Submit"} onClick={handleSave} />
+            </div>
+          </div>
+        </form>
+      ) : (
+        <ErrorPage />
+      )}
+    </PageContainer>
+  );
+}

--- a/front/src/pages/researchLine/researchLineList.jsx
+++ b/front/src/pages/researchLine/researchLineList.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import "../../styles/researchLineList.scss";
+import Table from "../../components/Table/table";
+import { getResearchLines, deleteResearchLine } from "../../api/research_line";
+import { useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import PageContainer from "../../components/PageContainer";
+
+export default function ResearchLineList() {
+  const navigate = useNavigate();
+  const [name] = useState(localStorage.getItem("name"));
+  const [role, setRole] = useState(localStorage.getItem("role"));
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [lines, setLines] = useState([]);
+
+  useEffect(() => {
+    const roles = ["Administrator", "Student", "Professor"];
+    const token = localStorage.getItem("token");
+    try {
+      const decoded = jwt_decode(token);
+      if (!roles.includes(decoded.role)) {
+        navigate("/");
+      }
+      setRole(decoded.role);
+    } catch (error) {
+      navigate("/login");
+    }
+  }, [setRole, navigate, role]);
+
+  const loadLines = () => {
+    setIsLoading(true);
+    getResearchLines()
+      .then((result) => {
+        let mapped = [];
+        if (result !== null && result !== undefined) {
+          mapped = result.map((line) => ({
+            Id: line.id,
+            Nome: line.name,
+          }));
+        }
+        setLines(mapped);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.log(error);
+        setError(true);
+        setIsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    loadLines();
+  }, []);
+
+  const handleDelete = (id) => {
+    deleteResearchLine(id).then(() => loadLines());
+  };
+
+  return (
+    <PageContainer name={name} isLoading={isLoading}>
+      {!error ? (
+        <>
+          <div className="researchBar">
+            <div className="left-bar">
+              <div>
+                <img src="research.png" alt="A logo representing Research Lines" height={"100rem"} />
+              </div>
+              <div className="title">Linhas de Pesquisa</div>
+            </div>
+            {role === 'Administrator' && (
+              <div className="right-bar">
+                <div className="create-button">
+                  <button onClick={() => navigate('/researchLines/add')}>Nova Linha</button>
+                </div>
+              </div>
+            )}
+          </div>
+          <BackButton />
+          <Table
+            data={lines}
+            useOptions={role === 'Administrator'}
+            deleteCallback={handleDelete}
+            detailsCallback={(id) => navigate(`${id}/edit`)}
+          />
+        </>
+      ) : (
+        <ErrorPage />
+      )}
+    </PageContainer>
+  );
+}

--- a/front/src/pages/researchLine/updateResearchLine.jsx
+++ b/front/src/pages/researchLine/updateResearchLine.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import "../../styles/form.scss";
+import { useNavigate, useParams } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import PageContainer from "../../components/PageContainer";
+import { getResearchLines } from "../../api/research_line";
+import { putResearchLine } from "../../api/research_line";
+
+export default function UpdateResearchLine() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [name] = useState(localStorage.getItem("name"));
+  const [role, setRole] = useState(localStorage.getItem("role"));
+  const [line, setLine] = useState({ name: "" });
+  const [error, setError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const roles = ["Administrator"];
+    const token = localStorage.getItem("token");
+    try {
+      const decoded = jwt_decode(token);
+      if (!roles.includes(decoded.role)) {
+        navigate("/");
+      }
+      setRole(decoded.role);
+    } catch (error) {
+      navigate("/login");
+    }
+  }, [setRole, navigate, role]);
+
+  useEffect(() => {
+    getResearchLines()
+      .then((result) => {
+        const current = result.find((x) => x.id === id);
+        if (current) {
+          setLine({ name: current.name });
+        }
+        setIsLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setIsLoading(false);
+      });
+  }, [id]);
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    putResearchLine(id, line)
+      .then(() => navigate(-1))
+      .catch(() => setError(true));
+  };
+
+  return (
+    <PageContainer name={name} isLoading={isLoading}>
+      <BackButton />
+      {!error ? (
+        <form className="form">
+          <div className="form-section">
+            <div className="formInput">
+              <label htmlFor="name">Nome</label>
+              <input
+                required
+                type="text"
+                name="name"
+                value={line.name}
+                onChange={(e) => setLine({ name: e.target.value })}
+                id="name"
+              />
+            </div>
+          </div>
+          <div className="form-section">
+            <div className="formInput">
+              <input type="submit" value={"Update"} onClick={handleSave} />
+            </div>
+          </div>
+        </form>
+      ) : (
+        <ErrorPage />
+      )}
+    </PageContainer>
+  );
+}

--- a/front/src/styles/researchLineList.scss
+++ b/front/src/styles/researchLineList.scss
@@ -1,0 +1,48 @@
+.researchBar {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .left-bar {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        flex-direction: row;
+
+        .title {
+            text-align: center;
+            font-size: xx-large;
+            font-weight: bolder;
+        }
+    }
+
+    .right-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        align-items: center;
+        flex-direction: row;
+        padding: 1rem;
+
+        button {
+            border-radius: 2rem;
+            padding: 1rem;
+            color: white;
+            margin: 0.5rem;
+            font-weight: bold;
+            background: #004AAD;
+        }
+
+        input {
+            visibility: hidden;
+            border-radius: 1rem;
+            text-align: center;
+            padding: 0.5rem;
+            color: #004AAD;
+            border: 2px solid #004AAD;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend research line API with CRUD functions
- implement pages to list, create and update research lines
- wire routes for the new pages and styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a19c525c83319b83839acb800c43