### PR TITLE
Add course management pages

### DIFF
--- a/backend/Controllers/StudentController.cs
+++ b/backend/Controllers/StudentController.cs
@@ -62,6 +62,21 @@ namespace saga.Controllers
             }
         }
 
+        [HttpPost("export")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> ExportStudents([FromBody] IEnumerable<string> fields)
+        {
+            try
+            {
+                var bytes = await _studentService.ExportToCsvAsync(fields);
+                return File(bytes, "text/csv", "students.csv");
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
         [HttpGet("{studentId}")]
         [Authorize(Roles = "Administrator, Professor, Student")]
         public async Task<ActionResult<StudentInfoDto>> GetStudent(Guid studentId)

--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -59,5 +59,36 @@ namespace saga.Controllers
                 return BadRequest(ex.Message);
             }
         }
+
+        [HttpGet]
+        [Authorize(Roles = "Administrator")]
+        [ProducesResponseType(typeof(IEnumerable<UserDto>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<UserDto>>> GetUsers()
+        {
+            try
+            {
+                var users = await _userService.GetAllUsersAsync();
+                return Ok(users);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteUser(Guid id)
+        {
+            try
+            {
+                await _userService.DeleteUserAsync(id);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
     }
 }

--- a/backend/Infrastructure/Jobs/StudentsFinishing.cs
+++ b/backend/Infrastructure/Jobs/StudentsFinishing.cs
@@ -47,13 +47,9 @@ namespace Infrastructure.Jobs
 
         private async Task NotifyProfessorAsync(IGrouping<Guid, OrientationEntity> groupedOrientations, Dictionary<Guid, StudentEntity> studentInfo)
         {
-            string emailSubject = "Próximas Defesas de Alunos";
-            var body = new StringBuilder();
-            body.AppendLine("Os seguintes estudantes estão concluindo o curso:");
-
-            string emailBody = EmailTemplates.EmailTemplates.StudentsFinishingFromProfessorEmailTemplate(groupedOrientations, studentInfo);
+            var content = EmailTemplates.EmailTemplates.StudentsFinishingFromProfessorEmailTemplate(groupedOrientations, studentInfo);
             string professorEmail = groupedOrientations?.FirstOrDefault()?.Professor?.Email;
-            await _emailSender.SendEmail(professorEmail, emailSubject, emailBody).ConfigureAwait(false);
+            await _emailSender.SendEmail(professorEmail, content.Subject, content.Body).ConfigureAwait(false);
         }
 
         private async Task NotifyStudentAsync(StudentEntity student)
@@ -70,10 +66,9 @@ namespace Infrastructure.Jobs
             }
 
             string defenseTypeText = string.Join(" e ", defenseTypes);
-            string emailSubject = $"Data limite de {defenseTypeText} se aproximando.";
-            string emailBody = EmailTemplates.EmailTemplates.UpcomingDefenseEmailTemplate(student.User?.FirstName, defenseTypeText, student.ProjectQualificationDate, student.ProjectDefenceDate);
+            var content = EmailTemplates.EmailTemplates.UpcomingDefenseEmailTemplate(student.User?.FirstName, defenseTypeText, student.ProjectQualificationDate, student.ProjectDefenceDate);
 
-            await _emailSender.SendEmail(student.User.Email, emailSubject, emailBody).ConfigureAwait(false);
+            await _emailSender.SendEmail(student.User.Email, content.Subject, content.Body).ConfigureAwait(false);
         }
 
         private async Task UpdateStudentAsync(StudentEntity student)

--- a/backend/Infrastructure/Providers/EmailTemplates.cs
+++ b/backend/Infrastructure/Providers/EmailTemplates.cs
@@ -3,58 +3,87 @@ using saga.Models.Entities;
 
 namespace Infrastructure.EmailTemplates
 {
+    public record EmailContent(string Subject, string Body);
+
+    public enum EmailLanguage
+    {
+        Pt,
+        En
+    }
+
     public static class EmailTemplates
     {
-        public static string WelcomeEmailTemplate(string resetPasswordPath, string token)
+        public static EmailContent WelcomeEmailTemplate(string resetPasswordPath, string token, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Bem-vindo(a) à Pós-Graduação do CEFET RJ!</p>
-                            <p>Para acessar sua conta, por favor, defina sua senha clicando no seguinte link:</p>
-                            <p><a href=""{resetPasswordPath}?token={token}"">{resetPasswordPath}?token={token}</a></p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? "Account Created" : "Sua conta foi criada";
+            string greeting = language == EmailLanguage.En ? "Welcome to the CEFET RJ Postgraduate Program!" : "Bem-vindo(a) à Pós-Graduação do CEFET RJ!";
+            string instruction = language == EmailLanguage.En ? "To access your account, please set your password using the link below:" : "Para acessar sua conta, por favor, defina sua senha clicando no seguinte link:";
+            string body = $"<html><body style='font-family: Arial, sans-serif;'>" +
+                         $"<p>{greeting}</p>" +
+                         $"<p>{instruction}</p>" +
+                         $"<p><a href='{resetPasswordPath}?token={token}'>{resetPasswordPath}?token={token}</a></p>" +
+                         "<br/>" +
+                         $"<p>{signature}</p>" +
+                         "</body></html>";
+            return new EmailContent(subject, body);
         }
 
-        public static string ResetPasswordEmailTemplate(string resetPasswordPath, string token)
+        public static EmailContent ResetPasswordEmailTemplate(string resetPasswordPath, string token, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Você solicitou a redefinição da sua senha. Por favor, clique no seguinte link para redefinir sua senha:</p>
-                            <p><a href=""{resetPasswordPath}?token={token}"">{resetPasswordPath}?token={token}</a></p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? "Password Reset" : "Alteração de senha";
+            string message = language == EmailLanguage.En ? "You requested a password reset. Click the link below:" : "Você solicitou a redefinição da sua senha. Por favor, clique no seguinte link para redefinir sua senha:";
+            string body = $"<html><body style='font-family: Arial, sans-serif;'>" +
+                         $"<p>{message}</p>" +
+                         $"<p><a href='{resetPasswordPath}?token={token}'>{resetPasswordPath}?token={token}</a></p>" +
+                         "<br/>" +
+                         $"<p>{signature}</p>" +
+                         "</body></html>";
+            return new EmailContent(subject, body);
         }
 
-        public static string UpcomingDefenseEmailTemplate(string? firstName, string defenseTypeText, DateTime? qualificationDate, DateTime? defenseDate)
+        public static EmailContent UpcomingDefenseEmailTemplate(string? firstName, string defenseTypeText, DateTime? qualificationDate, DateTime? defenseDate, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Prezado(a) {firstName},</p>
-                            <p>Este é um lembrete de que a data da sua {defenseTypeText} está se aproximando. Por favor, certifique-se de se preparar e estar pronto(a) para a sua apresentação.</p>
-                            <p>Se tiver alguma dúvida ou precisar de ajuda, sinta-se à vontade para entrar em contato com o seu orientador.</p>
-                            <p>Se você precisar de mais tempo para se preparar adequadamente, pode solicitar uma prorrogação entrando em contato com o seu orientador acadêmico.</p>
-                            <p>Data da sua Qualificação: {qualificationDate}</p>
-                            <p>Data da sua Defesa: {defenseDate}</p>
-                            <br>
-                            <p>Atenciosamente,</p>
-                            <p>A Equipe Acadêmica</p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? $"Upcoming {defenseTypeText} deadline" : $"Data limite de {defenseTypeText} se aproximando.";
+            var body = new StringBuilder();
+            body.Append("<html><body style='font-family: Arial, sans-serif;'>");
+            if (language == EmailLanguage.En)
+            {
+                body.Append($"<p>Dear {firstName},</p>");
+                body.Append($"<p>This is a reminder that your {defenseTypeText} date is approaching. Please be prepared for your presentation.</p>");
+                body.Append("<p>If you have any questions or need help, contact your advisor.</p>");
+                body.Append("<p>If you need more time, you can request an extension through your academic advisor.</p>");
+                body.Append($"<p>Qualification Date: {qualificationDate}</p>");
+                body.Append($"<p>Defense Date: {defenseDate}</p>");
+            }
+            else
+            {
+                body.Append($"<p>Prezado(a) {firstName},</p>");
+                body.Append($"<p>Este é um lembrete de que a data da sua {defenseTypeText} está se aproximando. Por favor, certifique-se de se preparar e estar pronto(a) para a sua apresentação.</p>");
+                body.Append("<p>Se tiver alguma dúvida ou precisar de ajuda, sinta-se à vontade para entrar em contato com o seu orientador.</p>");
+                body.Append("<p>Se você precisar de mais tempo para se preparar adequadamente, pode solicitar uma prorrogação entrando em contato com o seu orientador acadêmico.</p>");
+                body.Append($"<p>Data da sua Qualificação: {qualificationDate}</p>");
+                body.Append($"<p>Data da sua Defesa: {defenseDate}</p>");
+            }
+            body.Append("<br/>");
+            body.Append($"<p>{signature}</p>");
+            body.Append("</body></html>");
+            return new EmailContent(subject, body.ToString());
         }
 
-        public static string StudentsFinishingFromProfessorEmailTemplate(IGrouping<Guid, OrientationEntity> orientations, Dictionary<Guid, StudentEntity> students)
+        public static EmailContent StudentsFinishingFromProfessorEmailTemplate(IGrouping<Guid, OrientationEntity> orientations, Dictionary<Guid, StudentEntity> students, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
+            string subject = language == EmailLanguage.En ? "Upcoming Student Defenses" : "Próximas Defesas de Alunos";
             var body = new StringBuilder();
 
-            body.AppendLine("Os seguintes estudantes estão concluindo o curso:");
-            body.AppendLine("<table>");
+            body.AppendLine("<html><body style='font-family: Arial, sans-serif;'>");
+            body.AppendLine(language == EmailLanguage.En ? "<p>The following students are finishing the course:</p>" : "<p>Os seguintes estudantes estão concluindo o curso:</p>");
+            body.AppendLine("<table style='border-collapse: collapse; width: 100%;'>");
             body.AppendLine("<tr>");
-            body.AppendLine("<th>Nome</th>");
-            body.AppendLine("<th>Sobrenome</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>First Name</th>" : "<th>Nome</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Last Name</th>" : "<th>Sobrenome</th>");
             body.AppendLine("<th>Email</th>");
-            body.AppendLine("<th>Data de Defesa</th>");
-            body.AppendLine("<th>Data de Qualificação</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Defense Date</th>" : "<th>Data de Defesa</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Qualification Date</th>" : "<th>Data de Qualificação</th>");
             body.AppendLine("</tr>");
 
             foreach (var orientation in orientations)
@@ -72,7 +101,10 @@ namespace Infrastructure.EmailTemplates
             }
 
             body.AppendLine("</table>");
-            return body.ToString();
+            body.AppendLine("<br/>");
+            body.AppendLine($"<p>{signature}</p>");
+            body.AppendLine("</body></html>");
+            return new EmailContent(subject, body.ToString());
         }
     }
 }

--- a/backend/Migrations/20250623185228_AddGenderColumn.cs
+++ b/backend/Migrations/20250623185228_AddGenderColumn.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace saga.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGenderColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Gender",
+                table: "Students",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "Students");
+        }
+    }
+}

--- a/backend/Migrations/ContexRepositoryModelSnapshot.cs
+++ b/backend/Migrations/ContexRepositoryModelSnapshot.cs
@@ -207,6 +207,9 @@ namespace saga.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 
+                    b.Property<int>("Gender")
+                        .HasColumnType("integer");
+
                     b.HasKey("Id");
 
                     b.HasIndex("ResearchLineId");

--- a/backend/Models/DTOs/Student/StudentDto.cs
+++ b/backend/Models/DTOs/Student/StudentDto.cs
@@ -15,6 +15,8 @@ namespace saga.Models.DTOs
 
         public StatusEnum Status { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public DateTime? EntryDate { get; set; }
 
         public DateTime? ProjectDefenceDate { get; set; }

--- a/backend/Models/DTOs/Student/StudentInfoDto.cs
+++ b/backend/Models/DTOs/Student/StudentInfoDto.cs
@@ -14,6 +14,8 @@ namespace saga.Models.DTOs
 
         public StatusEnum Status { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public DateTime? EntryDate { get; set; }
 
         public DateTime? ProjectDefenceDate { get; set; }

--- a/backend/Models/Entities/StudentEntity.cs
+++ b/backend/Models/Entities/StudentEntity.cs
@@ -37,6 +37,11 @@ namespace saga.Models.Entities
         public StatusEnum Status { get; set; }
 
         /// <summary>
+        /// The gender of the student.
+        /// </summary>
+        public GenderEnum Gender { get; set; }
+
+        /// <summary>
         /// The date on which the student entered the program.
         /// </summary>
         public DateTime? EntryDate { get; set; }

--- a/backend/Models/Enums/GenderEnum.cs
+++ b/backend/Models/Enums/GenderEnum.cs
@@ -1,0 +1,15 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace saga.Models.Enums
+{
+    public enum GenderEnum
+    {
+        Default,
+        [Name("Masculino")]
+        Male,
+        [Name("Feminino")]
+        Female,
+        [Name("Outro")]
+        Other
+    }
+}

--- a/backend/Models/Mapper/StudentMapper.cs
+++ b/backend/Models/Mapper/StudentMapper.cs
@@ -23,6 +23,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = dto.RegistrationDate?.ToUniversalTime(),
                 ProjectId = dto.ProjectId,
                 Status = dto.Status,
+                Gender = dto.Gender,
                 EntryDate = dto.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = dto.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = dto.ProjectQualificationDate?.ToUniversalTime(),
@@ -48,6 +49,7 @@ namespace saga.Models.Mapper
         {
             entityToUpdate.ProjectId = self.ProjectId;
             entityToUpdate.Status = self.Status;
+            entityToUpdate.Gender = self.Gender;
             entityToUpdate.EntryDate = self.EntryDate;
             entityToUpdate.ProjectDefenceDate = self.ProjectDefenceDate;
             entityToUpdate.ProjectQualificationDate = self.ProjectQualificationDate;
@@ -81,6 +83,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = self.RegistrationDate?.ToUniversalTime(),
                 ProjectId = self.ProjectId,
                 Status = self.Status,
+                Gender = self.Gender,
                 EntryDate = self.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = self.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = self.ProjectQualificationDate?.ToUniversalTime(),
@@ -111,6 +114,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = self.RegistrationDate?.ToUniversalTime(),
                 ProjectId = self.ProjectId,
                 Status = self.Status,
+                Gender = self.Gender,
                 EntryDate = self.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = self.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = self.ProjectQualificationDate?.ToUniversalTime(),

--- a/backend/Services/Interfaces/IStudentService.cs
+++ b/backend/Services/Interfaces/IStudentService.cs
@@ -62,5 +62,12 @@ namespace saga.Services.Interfaces
         /// </summary>
         /// <returns>A list of all student entities.</returns>
         Task<IEnumerable<StudentInfoDto>> GetAllStudentsAsync();
+
+        /// <summary>
+        /// Generates a CSV containing the selected fields for all students.
+        /// </summary>
+        /// <param name="fields">Fields to include in the CSV.</param>
+        /// <returns>CSV file bytes.</returns>
+        Task<byte[]> ExportToCsvAsync(IEnumerable<string> fields);
     }
 }

--- a/backend/Services/Interfaces/IUserService.cs
+++ b/backend/Services/Interfaces/IUserService.cs
@@ -38,5 +38,17 @@ namespace saga.Services.Interfaces
         /// <returns>A task representing the asynchronous password reset operation.</returns>
         /// <exception cref="ArgumentException">Thrown when the user with the specified email is not found.</exception>
         Task<LoginResultDto> ResetPasswordAsync(ResetPasswordDto loginDto);
+
+        /// <summary>
+        /// Retrieves all users registered in the system.
+        /// </summary>
+        /// <returns>A collection of users.</returns>
+        Task<IEnumerable<UserDto>> GetAllUsersAsync();
+
+        /// <summary>
+        /// Removes a user by its identifier.
+        /// </summary>
+        /// <param name="id">User identifier.</param>
+        Task DeleteUserAsync(Guid id);
     }
 }

--- a/backend/Services/StudentService.cs
+++ b/backend/Services/StudentService.cs
@@ -127,6 +127,50 @@ namespace saga.Services
             await _repository.Student.DeactiveAsync(existingStudent);
         }
 
+        /// <inheritdoc />
+        public async Task<byte[]> ExportToCsvAsync(IEnumerable<string> fields)
+        {
+            if (fields == null || !fields.Any())
+            {
+                throw new ArgumentException("No fields provided for export");
+            }
+
+            var students = await _repository.Student.GetAllAsync(s => s.User);
+            var dtos = students.Select(s => s.ToInfoDto()).ToList();
+
+            using var memoryStream = new MemoryStream();
+            using (var writer = new StreamWriter(memoryStream, leaveOpen: true))
+            using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+            {
+                foreach (var field in fields)
+                {
+                    csv.WriteField(field);
+                }
+                await csv.NextRecordAsync();
+
+                foreach (var dto in dtos)
+                {
+                    foreach (var field in fields)
+                    {
+                        var prop = typeof(StudentInfoDto).GetProperty(field);
+                        var value = prop?.GetValue(dto);
+                        if (value is DateTime dateTime)
+                        {
+                            csv.WriteField(dateTime.ToString("O"));
+                        }
+                        else
+                        {
+                            csv.WriteField(value);
+                        }
+                    }
+                    await csv.NextRecordAsync();
+                }
+            }
+
+            memoryStream.Position = 0;
+            return memoryStream.ToArray();
+        }
+
         private async Task<StudentEntity> GetExistingStudentAsync(Guid id)
         {
             var existingStudent = await _repository.Student.GetByIdAsync(id);

--- a/backend/Services/UserService.cs
+++ b/backend/Services/UserService.cs
@@ -9,6 +9,7 @@ using saga.Models.Entities;
 using saga.Models.Mapper;
 using saga.Properties;
 using saga.Services.Interfaces;
+using System.Linq;
 
 namespace saga.Services
 {
@@ -48,9 +49,8 @@ namespace saga.Services
             }
             var user = await _repository.User.AddAsync(userDto.ToUserEntity());
             var token = _tokenProvider.GenerateResetPasswordJwt(user, TimeSpan.FromDays(7));
-            string emailSubject = "Sua conta foi criada";
-            string emailBody = EmailTemplates.WelcomeEmailTemplate(userDto.ResetPasswordPath, token);
-            await _emailSender.SendEmail(userDto.Email, emailSubject, emailBody).ConfigureAwait(false);
+            var content = EmailTemplates.WelcomeEmailTemplate(userDto.ResetPasswordPath, token);
+            await _emailSender.SendEmail(userDto.Email, content.Subject, content.Body).ConfigureAwait(false);
             return user;
         }
 
@@ -60,9 +60,8 @@ namespace saga.Services
             var user = await _repository.User.GetUserByEmail(request.Email) ?? throw new ArgumentException($"User with email {request.Email} not found.");
 
             var token = _tokenProvider.GenerateResetPasswordJwt(user, TimeSpan.FromMinutes(30));
-            string emailSubject = "Alteração de senha";
-            string emailBody = EmailTemplates.ResetPasswordEmailTemplate(request.ResetPasswordPath, token);
-            await _emailSender.SendEmail(request.Email, emailSubject, emailBody).ConfigureAwait(false);
+            var resetContent = EmailTemplates.ResetPasswordEmailTemplate(request.ResetPasswordPath, token);
+            await _emailSender.SendEmail(request.Email, resetContent.Subject, resetContent.Body).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -102,6 +101,19 @@ namespace saga.Services
             }
 
             return user.ToDto(_tokenProvider.GenerateJwtToken(user));
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<UserDto>> GetAllUsersAsync()
+        {
+            var users = await _repository.User.GetAllAsync();
+            return users.Select(u => u.ToUserDto());
+        }
+
+        /// <inheritdoc />
+        public async Task DeleteUserAsync(Guid id)
+        {
+            await _repository.User.DeactiveByIdAsync(id);
         }
 
         private string HashPassword(string password)

--- a/backend/tests/CourseServiceTests.cs
+++ b/backend/tests/CourseServiceTests.cs
@@ -27,4 +27,51 @@ public class CourseServiceTests : TestBase
         Assert.Equal("Algorithms", retrieved.Name);
         Assert.Equal("CS101", retrieved.CourseUnique);
     }
+
+    [Fact]
+    public async Task UpdateCourse()
+    {
+        var logger = new Mock<ILogger<CourseService>>();
+        var service = new CourseService(Repository, logger.Object);
+
+        var created = await service.CreateCourseAsync(new CourseDto
+        {
+            Name = "Algorithms",
+            CourseUnique = "CS101",
+            Credits = 4
+        });
+
+        var updated = await service.UpdateCourseAsync(created.Id!.Value, new CourseDto
+        {
+            Name = "Data Structures",
+            CourseUnique = "CS102",
+            Credits = 3
+        });
+
+        Assert.Equal("Data Structures", updated.Name);
+        Assert.Equal("CS102", updated.CourseUnique);
+
+        var retrieved = await service.GetCourseAsync(created.Id.Value);
+        Assert.Equal("Data Structures", retrieved.Name);
+        Assert.Equal("CS102", retrieved.CourseUnique);
+    }
+
+    [Fact]
+    public async Task DeleteCourse()
+    {
+        var logger = new Mock<ILogger<CourseService>>();
+        var service = new CourseService(Repository, logger.Object);
+
+        var created = await service.CreateCourseAsync(new CourseDto
+        {
+            Name = "Algorithms",
+            CourseUnique = "CS101",
+            Credits = 4
+        });
+
+        await service.DeleteCourseAsync(created.Id!.Value);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.GetCourseAsync(created.Id.Value));
+    }
 }

--- a/backend/tests/ProjectServiceTests.cs
+++ b/backend/tests/ProjectServiceTests.cs
@@ -30,4 +30,56 @@ public class ProjectServiceTests : TestBase
         Assert.Equal("ProjectX", retrieved.Name);
         Assert.Equal(researchLine.Id, retrieved.ResearchLineId);
     }
+
+    [Fact]
+    public async Task UpdateProject()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var logger = new Mock<ILogger<ProjectService>>();
+        var service = new ProjectService(Repository, logger.Object);
+
+        var created = await service.CreateProjectAsync(new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectX",
+            Status = ProjectStatusEnum.Active,
+            ProfessorIds = new List<string>()
+        });
+
+        var updated = await service.UpdateProjectAsync(created.Id!.Value, new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectY",
+            Status = ProjectStatusEnum.Closed,
+            ProfessorIds = new List<string>()
+        });
+
+        Assert.Equal(ProjectStatusEnum.Closed, updated.Status);
+        Assert.Equal("ProjectY", updated.Name);
+
+        var retrieved = await service.GetProjectAsync(created.Id.Value);
+        Assert.Equal(ProjectStatusEnum.Closed, retrieved.Status);
+        Assert.Equal("ProjectY", retrieved.Name);
+    }
+
+    [Fact]
+    public async Task DeleteProject()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var logger = new Mock<ILogger<ProjectService>>();
+        var service = new ProjectService(Repository, logger.Object);
+
+        var created = await service.CreateProjectAsync(new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectX",
+            Status = ProjectStatusEnum.Active,
+            ProfessorIds = new List<string>()
+        });
+
+        await service.DeleteProjectAsync(created.Id!.Value);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.GetProjectAsync(created.Id.Value));
+    }
 }

--- a/backend/tests/StudentServiceTests.cs
+++ b/backend/tests/StudentServiceTests.cs
@@ -32,7 +32,10 @@ public class StudentServiceTests : TestBase
             Email = "student@example.com",
             Cpf = "12345678901",
             Registration = "2023",
-            Role = RolesEnum.Student
+            Role = RolesEnum.Student,
+            Gender = GenderEnum.Male,
+            Status = StatusEnum.Active,
+            Proficiency = true
         };
 
         var created = await service.CreateStudentAsync(dto);
@@ -41,5 +44,37 @@ public class StudentServiceTests : TestBase
         var retrieved = await service.GetStudentAsync(created.Id);
         Assert.Equal("2023", retrieved.Registration);
         Assert.Equal("student@example.com", retrieved.Email);
+        Assert.Equal(GenderEnum.Male, retrieved.Gender);
+        Assert.Equal(StatusEnum.Active, retrieved.Status);
+        Assert.True(retrieved.Proficiency);
+    }
+
+    [Fact]
+    public async Task ExportStudentsToCsv()
+    {
+        var user = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "export@example.com",
+            Cpf = "98765432100",
+            Role = RolesEnum.Student,
+            PasswordHash = "pwd",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await Repository.Student.AddAsync(new StudentEntity
+        {
+            UserId = user.Id,
+            Registration = "R1"
+        });
+
+        var logger = new Mock<ILogger<StudentService>>();
+        var service = new StudentService(Repository, logger.Object, Mock.Of<IUserService>());
+
+        var csv = await service.ExportToCsvAsync(new[] { "Registration", "Email" });
+        var content = System.Text.Encoding.UTF8.GetString(csv);
+
+        Assert.Contains("Registration,Email", content);
+        Assert.Contains("R1", content);
+        Assert.Contains("export@example.com", content);
     }
 }

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -23,6 +23,9 @@ import StudentForm from './pages/student/CreateStudent';
 import ProjectProfile from './pages/projects/profile';
 import ResearchUpdate from './pages/research/updateResearch';
 import ExtensionUpdate from './pages/extension/updateExtension';
+import CourseList from './pages/course/courseList';
+import CreateCourse from './pages/course/createCourse';
+import UpdateCourse from './pages/course/updateCourse';
 
 export default function App() {
   return (
@@ -38,6 +41,7 @@ export default function App() {
         <Route path="/researchers" element={<ResearcherList />} />
         <Route path="/researches" element={<ResearchList />} />
         <Route path="/extensions" element={<ExtensionList />} />
+        <Route path="/courses" element={<CourseList />} />
         <Route path="/projects" element={<ProjectList />} />
         <Route path="/user/add" element={<UserForm />} />
         <Route path="/entities/csv" element={<CsvLoader />} />
@@ -51,6 +55,8 @@ export default function App() {
         <Route path="/projects/add" element={<ProjectForm />} />
         <Route path="/projects/:id" element={<ProjectProfile />} />
         <Route path="/projects/:id/edit" element={<ProjectForm Update={true} />} />
+        <Route path="/courses/add" element={<CreateCourse />} />
+        <Route path="/courses/:id/edit" element={<UpdateCourse />} />
         <Route path="/students/:id/extensions/add" element={<ExtensionForm />} />
         <Route path="/researches/:id/edit" element={<ResearchUpdate />} />
         <Route path="/extensions/:id/edit" element={<ExtensionUpdate />} />

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -5,9 +5,12 @@ import Login from "./pages/login";
 import ResetPassword from "./pages/changePassword";
 import StudentProfile from "./pages/student/profile";
 import UserForm from './pages/user/createUser';
+import UserList from './pages/user/userList';
+import UserUpdate from './pages/user/userUpdate';
 import StudentList from './pages/student/StudentList';
 import ProfessorList from './pages/professor/professorList';
 import ResearcherList from './pages/researcher/researcherList';
+import ResearcherProfile from './pages/researcher/profile';
 import ProjectList from './pages/projects/projectList';
 import ProjectForm from './pages/projects/createProject';
 import ExtensionList from './pages/extension/extensionList';
@@ -26,6 +29,9 @@ import ExtensionUpdate from './pages/extension/updateExtension';
 import CourseList from './pages/course/courseList';
 import CreateCourse from './pages/course/createCourse';
 import UpdateCourse from './pages/course/updateCourse';
+import ResearchLineList from './pages/researchLine/researchLineList';
+import CreateResearchLine from './pages/researchLine/createResearchLine';
+import UpdateResearchLine from './pages/researchLine/updateResearchLine';
 
 export default function App() {
   return (
@@ -43,6 +49,8 @@ export default function App() {
         <Route path="/extensions" element={<ExtensionList />} />
         <Route path="/courses" element={<CourseList />} />
         <Route path="/projects" element={<ProjectList />} />
+        <Route path="/users" element={<UserList />} />
+        <Route path="/users/:role/:id/edit" element={<UserUpdate />} />
         <Route path="/user/add" element={<UserForm />} />
         <Route path="/entities/csv" element={<CsvLoader />} />
         <Route path="/students/:id/researches/add" element={<ResearchForm />} />
@@ -51,7 +59,8 @@ export default function App() {
         <Route path="/researches/add" element={<UserForm type={"Externo"}/>} />
         <Route path="/professors/:id" element={<ProfessorProfile/>} />
         <Route path="/professors/:id/edit" element={<ProfessorUpdate/>} />
-        <Route path="/researchers/:id" element={<ResearcherUpdate />} />
+        <Route path="/researchers/:id" element={<ResearcherProfile />} />
+        <Route path="/researchers/:id/edit" element={<ResearcherUpdate />} />
         <Route path="/projects/add" element={<ProjectForm />} />
         <Route path="/projects/:id" element={<ProjectProfile />} />
         <Route path="/projects/:id/edit" element={<ProjectForm Update={true} />} />
@@ -60,6 +69,9 @@ export default function App() {
         <Route path="/students/:id/extensions/add" element={<ExtensionForm />} />
         <Route path="/researches/:id/edit" element={<ResearchUpdate />} />
         <Route path="/extensions/:id/edit" element={<ExtensionUpdate />} />
+        <Route path="/researchLines" element={<ResearchLineList />} />
+        <Route path="/researchLines/add" element={<CreateResearchLine />} />
+        <Route path="/researchLines/:id/edit" element={<UpdateResearchLine />} />
       </Routes>
     </Router>
   );

--- a/front/src/api/_api.js
+++ b/front/src/api/_api.js
@@ -26,6 +26,12 @@ api.interceptors.request.use(
         localStorage.removeItem('role')
       }
       return response
+    },
+    (error)=>{
+      if(error.response){
+        return Promise.reject(error.response.data)
+      }
+      return Promise.reject({ message: error.message })
     }
   )
 

--- a/front/src/api/course_service.js
+++ b/front/src/api/course_service.js
@@ -1,0 +1,21 @@
+import api from './_api'
+
+export async function getCourses(){
+    return (await api.get("courses"))?.data
+}
+
+export async function getCourseById(id){
+    return (await api.get(`courses/${id}`))?.data
+}
+
+export async function postCourse(data){
+    return (await api.post("courses", data))?.data
+}
+
+export async function putCourseById(id, data){
+    return (await api.put(`courses/${id}`, data))?.data
+}
+
+export async function deleteCourse(id){
+    return await api.delete(`courses/${id}`)
+}

--- a/front/src/api/research_line.js
+++ b/front/src/api/research_line.js
@@ -3,3 +3,15 @@ import api from './_api'
 export async function getResearchLines(){
     return (await api.get("researchLines"))?.data
 }
+
+export async function postResearchLine(data){
+    return (await api.post("researchLines", data))?.data
+}
+
+export async function putResearchLine(id, data){
+    return (await api.put(`researchLines/${id}`, data))?.data
+}
+
+export async function deleteResearchLine(id){
+    return await api.delete(`researchLines/${id}`)
+}

--- a/front/src/api/student_service.js
+++ b/front/src/api/student_service.js
@@ -33,3 +33,8 @@ export async function postStudentCourseCsv(formData){
         },
       }))?.data
 }
+
+export async function exportStudentsCsv(fields){
+    const response = await api.post(`api/Students/export`, fields, { responseType: 'blob' });
+    return response.data
+}

--- a/front/src/api/user_service.js
+++ b/front/src/api/user_service.js
@@ -17,8 +17,16 @@ export function Login({email, password})
         return api.postWithoutToken('users/resetPassword', { password }, config)
     }
 
-    export function ForgotPassword({email, resetPasswordPath})
-    {
-        return api.postWithoutToken('users/resetPasswordRequet', { email, resetPasswordPath })
-    }
+export function ForgotPassword({email, resetPasswordPath})
+{
+    return api.postWithoutToken('users/resetPasswordRequet', { email, resetPasswordPath })
+}
+
+export async function getUsers(){
+    return (await api.get('users'))?.data
+}
+
+export async function deleteUser(id){
+    return (await api.delete(`users/${id}`))?.data
+}
 

--- a/front/src/components/PageContainer.jsx
+++ b/front/src/components/PageContainer.jsx
@@ -12,6 +12,10 @@ export default function PageContainer({ children, name, isLoading }) {
     const navigate = useNavigate()
     useEffect(() => {
         const token = localStorage.getItem('token')
+        if (!token) {
+            navigate('/login')
+            return
+        }
         try {
             const decoded = jwt_decode(token)
             if (decoded.exp < (Date.now()/1000)) {

--- a/front/src/components/error/InlineError.jsx
+++ b/front/src/components/error/InlineError.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import './inlineError.scss';
+
+const InlineError = ({ message }) => {
+  if (!message) return null;
+  return <div className="inline-error">{message}</div>;
+};
+
+export default InlineError;

--- a/front/src/components/error/inlineError.scss
+++ b/front/src/components/error/inlineError.scss
@@ -1,0 +1,4 @@
+.inline-error {
+  color: red;
+  margin-top: 0.5rem;
+}

--- a/front/src/components/header.jsx
+++ b/front/src/components/header.jsx
@@ -4,6 +4,14 @@ import '../styles/header.scss'
 
 export default function Header({ name }) {
     const navigate = useNavigate()
+
+    const handleLogout = () => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        localStorage.removeItem('name');
+        navigate('/login');
+    }
+
     return (
         <>
             <div className={"header"}>
@@ -13,6 +21,7 @@ export default function Header({ name }) {
                 </div>
                 <div className={"headerOptions"}>
                     <div>Olá, {name}</div>
+                    <div style={{cursor:'pointer'}} onClick={handleLogout}>Logout</div>
                 </div>
             </div>
             <div className={"headerBreak"}><span></span></div>

--- a/front/src/enum_helpers.js
+++ b/front/src/enum_helpers.js
@@ -13,6 +13,13 @@ export const AREA_ENUM = [
     { key: 2, name: "Graduated", translation: "Formado" },
     { key: 3, name: "Disconnected", translation: "Desconectado" },
   ];
+
+  export const GENDER_ENUM = [
+    { key: 0, name: "Default", translation: "Padrão" },
+    { key: 1, name: "Male", translation: "Masculino" },
+    { key: 2, name: "Female", translation: "Feminino" },
+    { key: 3, name: "Other", translation: "Outro" },
+  ];
   
   export const ROLES_ENUM = [
     { key: 0, name: "Default", translation: "Padrão" },

--- a/front/src/pages/course/courseList.jsx
+++ b/front/src/pages/course/courseList.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react"
+import '../../styles/courseList.scss'
+import Table from "../../components/Table/table"
+import { getCourses } from "../../api/course_service"
+import { useNavigate } from "react-router"
+import jwt_decode from "jwt-decode"
+import BackButton from "../../components/BackButton"
+import PageContainer from "../../components/PageContainer"
+
+export default function CourseList(){
+    const navigate = useNavigate()
+    const [name] = useState(localStorage.getItem('name'))
+    const [role, setRole] = useState(localStorage.getItem('role'))
+    const [isLoading, setIsLoading] = useState(true)
+    const [courses, setCourses] = useState([])
+
+    useEffect(()=>{
+        const roles = ['Administrator','Professor','Student']
+        const token = localStorage.getItem('token')
+        try{
+            const decoded = jwt_decode(token)
+            if(!roles.includes(decoded.role)){
+                navigate('/')
+            }
+            setRole(decoded.role)
+        }catch(err){
+            navigate('/login')
+        }
+    },[navigate])
+
+    useEffect(()=>{
+        getCourses()
+            .then(result=>{
+                let mapped = []
+                if(result){
+                    mapped = result.map(course=>({
+                        Id: course.id,
+                        Nome: course.name,
+                        Codigo: course.code,
+                        Creditos: course.credits,
+                        Conceito: course.concept,
+                        Eletiva: course.isElective ? 'Sim' : 'Nao'
+                    }))
+                }
+                setCourses(mapped)
+                setIsLoading(false)
+            })
+    },[])
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            <div className="courseBar">
+                <div className="left-bar">
+                    <div>
+                        <img src="lamp.png" alt="Course icon" height={"100rem"}/>
+                    </div>
+                    <div className="title">Cursos</div>
+                </div>
+                {role === 'Administrator' && <div className="right-bar">
+                    <div className="search">
+                        <input type="search" name="search" id="search" />
+                    </div>
+                    <div className="create-button">
+                        <button onClick={()=>navigate('/courses/add')}>Novo Curso</button>
+                    </div>
+                </div>}
+            </div>
+            <BackButton />
+            <Table data={courses} useOptions={role!=='Student'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+        </PageContainer>
+    )
+}

--- a/front/src/pages/course/createCourse.jsx
+++ b/front/src/pages/course/createCourse.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react"
+import '../../styles/form.scss'
+import { useNavigate } from "react-router"
+import jwt_decode from "jwt-decode"
+import BackButton from "../../components/BackButton"
+import PageContainer from "../../components/PageContainer"
+import { postCourse } from "../../api/course_service"
+
+export default function CreateCourse(){
+    const navigate = useNavigate()
+    const [name] = useState(localStorage.getItem('name'))
+    const [role, setRole] = useState(localStorage.getItem('role'))
+    const [course, setCourse] = useState({
+        name:'',
+        courseUnique:'',
+        credits:0,
+        code:'',
+        concept:'',
+        isElective:false
+    })
+
+    useEffect(()=>{
+        const token = localStorage.getItem('token')
+        try{
+            const decoded = jwt_decode(token)
+            if(decoded.role !== 'Administrator'){
+                navigate('/')
+            }
+            setRole(decoded.role)
+        }catch(err){
+            navigate('/login')
+        }
+    },[navigate])
+
+    const handleSave = (e)=>{
+        e.preventDefault()
+        postCourse(course)
+            .then(()=>navigate(-1))
+    }
+
+    return(
+        <PageContainer name={name} isLoading={false}>
+            <BackButton />
+            <form className='form'>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='name'>Nome</label>
+                        <input type='text' id='name' value={course.name} onChange={e=>setCourse({...course, name:e.target.value})} required />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='courseUnique'>Identificador</label>
+                        <input type='text' id='courseUnique' value={course.courseUnique} onChange={e=>setCourse({...course, courseUnique:e.target.value})} required />
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='credits'>Creditos</label>
+                        <input type='number' id='credits' value={course.credits} onChange={e=>setCourse({...course, credits:Number(e.target.value)})} />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='code'>Codigo</label>
+                        <input type='text' id='code' value={course.code} onChange={e=>setCourse({...course, code:e.target.value})} />
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='concept'>Conceito</label>
+                        <input type='text' id='concept' value={course.concept} onChange={e=>setCourse({...course, concept:e.target.value})} />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='isElective'>Eletiva</label>
+                        <select id='isElective' value={course.isElective ? '1':'0'} onChange={e=>setCourse({...course, isElective:e.target.value==='1'})}>
+                            <option value='0'>Não</option>
+                            <option value='1'>Sim</option>
+                        </select>
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <input type='submit' value='Submit' onClick={handleSave}/>
+                    </div>
+                </div>
+            </form>
+        </PageContainer>
+    )
+}

--- a/front/src/pages/course/updateCourse.jsx
+++ b/front/src/pages/course/updateCourse.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react"
+import '../../styles/form.scss'
+import { useNavigate, useParams } from "react-router"
+import jwt_decode from "jwt-decode"
+import BackButton from "../../components/BackButton"
+import PageContainer from "../../components/PageContainer"
+import { getCourseById, putCourseById } from "../../api/course_service"
+
+export default function UpdateCourse(){
+    const { id } = useParams()
+    const navigate = useNavigate()
+    const [name] = useState(localStorage.getItem('name'))
+    const [role, setRole] = useState(localStorage.getItem('role'))
+    const [course, setCourse] = useState(null)
+    const [isLoading, setIsLoading] = useState(true)
+
+    useEffect(()=>{
+        const token = localStorage.getItem('token')
+        try{
+            const decoded = jwt_decode(token)
+            if(decoded.role === 'Student'){
+                navigate('/')
+            }
+            setRole(decoded.role)
+        }catch(err){
+            navigate('/login')
+        }
+    },[navigate])
+
+    useEffect(()=>{
+        getCourseById(id)
+            .then(res=>{ setCourse(res); setIsLoading(false) })
+            .catch(()=>{ setIsLoading(false) })
+    },[id])
+
+    const handleSave = (e)=>{
+        e.preventDefault()
+        putCourseById(id, course)
+            .then(()=>navigate('/courses'))
+    }
+
+    if(!course) return <PageContainer name={name} isLoading={isLoading}><BackButton/></PageContainer>
+
+    return(
+        <PageContainer name={name} isLoading={isLoading}>
+            <BackButton />
+            <form className='form'>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='name'>Nome</label>
+                        <input type='text' id='name' value={course.name||''} onChange={e=>setCourse({...course, name:e.target.value})} required />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='courseUnique'>Identificador</label>
+                        <input type='text' id='courseUnique' value={course.courseUnique||''} onChange={e=>setCourse({...course, courseUnique:e.target.value})} required />
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='credits'>Creditos</label>
+                        <input type='number' id='credits' value={course.credits} onChange={e=>setCourse({...course, credits:Number(e.target.value)})} />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='code'>Codigo</label>
+                        <input type='text' id='code' value={course.code||''} onChange={e=>setCourse({...course, code:e.target.value})} />
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <label htmlFor='concept'>Conceito</label>
+                        <input type='text' id='concept' value={course.concept||''} onChange={e=>setCourse({...course, concept:e.target.value})} />
+                    </div>
+                    <div className='formInput'>
+                        <label htmlFor='isElective'>Eletiva</label>
+                        <select id='isElective' value={course.isElective ? '1':'0'} onChange={e=>setCourse({...course, isElective:e.target.value==='1'})}>
+                            <option value='0'>Não</option>
+                            <option value='1'>Sim</option>
+                        </select>
+                    </div>
+                </div>
+                <div className='form-section'>
+                    <div className='formInput'>
+                        <input type='submit' value='Update' onClick={handleSave}/>
+                    </div>
+                </div>
+            </form>
+        </PageContainer>
+    )
+}

--- a/front/src/pages/home.jsx
+++ b/front/src/pages/home.jsx
@@ -65,6 +65,12 @@ export default function Home() {
                     </div>
                     <label htmlFor='research' className={"iconLabel"}>Dissertações</label>
                 </div>}
+                {(role === "Administrator" || role === "Professor" || role === "Student") && <div className={"boardItem"} onClick={() => navigate('/courses')}>
+                    <div id='course' className={"itemIcon"} >
+                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/lamp.png"} />
+                    </div>
+                    <label htmlFor='course' className={"iconLabel"}>Cursos</label>
+                </div>}
                 {(role === "Administrator" || role === "Professor") && <div className={"boardItem"} onClick={() => navigate('/projects')}>
                     <div id='project' className={"itemIcon"} >
                         <img className={"filtered"} src={process.env.PUBLIC_URL +"/lamp.png"} />

--- a/front/src/pages/login.jsx
+++ b/front/src/pages/login.jsx
@@ -3,6 +3,7 @@ import '../styles/login.scss';
 import { useNavigate } from 'react-router-dom';
 import { Login as login, ForgotPassword as forgotPassword } from '../api/user_service';
 import jwt_decode from 'jwt-decode';
+import InlineError from '../components/error/InlineError';
 
 export default function Login() {
   const navigate = useNavigate();
@@ -36,8 +37,9 @@ export default function Login() {
           setError('login failed');
         }
       })
-      .catch(() => {
-        setError('login failed');
+      .catch((err) => {
+        const message = err?.message || 'login failed';
+        setError(message);
       });
   };
 
@@ -98,7 +100,7 @@ export default function Login() {
               onChange={(e) => setPassword(e.target.value)}
             />
             <input type="submit" id="submit" value={'Login'} onClick={handleSubmit} />
-            {error && <p> {error} </p>}
+            <InlineError message={error} />
             <button id="forgotPassword" onClick={handleForgotPassword}>
               Esqueceu a senha?
             </button>

--- a/front/src/pages/research/createResearch.jsx
+++ b/front/src/pages/research/createResearch.jsx
@@ -7,7 +7,7 @@ import BackButton from "../../components/BackButton";
 import { getStudentById } from "../../api/student_service";
 import { getProjectById } from "../../api/project_service";
 import { getResearchers } from "../../api/researcher_service";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { postResearch } from "../../api/research_service";
 
@@ -93,6 +93,7 @@ export default function ResearchForm() {
       setTimeout(() => navigate(-1), 1000);
     } catch (err) {
       setError(true);
+      setErrorMessage(err?.message || 'Erro ao criar dissertação');
     }
   };
 
@@ -139,7 +140,7 @@ export default function ResearchForm() {
         </div>
       )}
       {success && <div className="success">Dissertação criada com sucesso</div>}
-      {error && <ErrorPage errorMessage={errorMessage} />}
+      {error && <InlineError message={errorMessage} />}
     </PageContainer>
   );
 }

--- a/front/src/pages/research/updateResearch.jsx
+++ b/front/src/pages/research/updateResearch.jsx
@@ -6,7 +6,7 @@ import Select from "../../components/select";
 import BackButton from "../../components/BackButton";
 import { getProjectById } from "../../api/project_service";
 import { getResearchers } from "../../api/researcher_service";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { getResearchById, putResearch } from "../../api/research_service";
 
@@ -86,6 +86,7 @@ export default function ResearchUpdate() {
       setTimeout(() => navigate(-1), 1000);
     } catch (err) {
       setError(true);
+      setErrorMessage(err?.message || 'Erro ao atualizar dissertação');
     }
   };
 
@@ -126,7 +127,7 @@ export default function ResearchUpdate() {
         </div>
       )}
       {success && <div className="success">Dissertação atualizada com sucesso</div>}
-      {error && <ErrorPage errorMessage={errorMessage} />}
+      {error && <InlineError message={errorMessage} />}
     </PageContainer>
   );
 }

--- a/front/src/pages/researchLine/createResearchLine.jsx
+++ b/front/src/pages/researchLine/createResearchLine.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import "../../styles/form.scss";
+import { useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import PageContainer from "../../components/PageContainer";
+import { postResearchLine } from "../../api/research_line";
+
+export default function CreateResearchLine() {
+  const navigate = useNavigate();
+  const [name] = useState(localStorage.getItem("name"));
+  const [role, setRole] = useState(localStorage.getItem("role"));
+  const [line, setLine] = useState({ name: "" });
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const roles = ["Administrator"];
+    const token = localStorage.getItem("token");
+    try {
+      const decoded = jwt_decode(token);
+      if (!roles.includes(decoded.role)) {
+        navigate("/");
+      }
+      setRole(decoded.role);
+    } catch (error) {
+      navigate("/login");
+    }
+  }, [setRole, navigate, role]);
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    postResearchLine(line)
+      .then(() => navigate(-1))
+      .catch(() => setError(true));
+  };
+
+  return (
+    <PageContainer name={name} isLoading={false}>
+      <BackButton />
+      {!error ? (
+        <form className="form">
+          <div className="form-section">
+            <div className="formInput">
+              <label htmlFor="name">Nome</label>
+              <input
+                required
+                type="text"
+                name="name"
+                value={line.name}
+                onChange={(e) => setLine({ name: e.target.value })}
+                id="name"
+              />
+            </div>
+          </div>
+          <div className="form-section">
+            <div className="formInput">
+              <input type="submit" value={"Submit"} onClick={handleSave} />
+            </div>
+          </div>
+        </form>
+      ) : (
+        <ErrorPage />
+      )}
+    </PageContainer>
+  );
+}

--- a/front/src/pages/researchLine/updateResearchLine.jsx
+++ b/front/src/pages/researchLine/updateResearchLine.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import "../../styles/form.scss";
+import { useNavigate, useParams } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import PageContainer from "../../components/PageContainer";
+import { getResearchLines } from "../../api/research_line";
+import { putResearchLine } from "../../api/research_line";
+
+export default function UpdateResearchLine() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [name] = useState(localStorage.getItem("name"));
+  const [role, setRole] = useState(localStorage.getItem("role"));
+  const [line, setLine] = useState({ name: "" });
+  const [error, setError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const roles = ["Administrator"];
+    const token = localStorage.getItem("token");
+    try {
+      const decoded = jwt_decode(token);
+      if (!roles.includes(decoded.role)) {
+        navigate("/");
+      }
+      setRole(decoded.role);
+    } catch (error) {
+      navigate("/login");
+    }
+  }, [setRole, navigate, role]);
+
+  useEffect(() => {
+    getResearchLines()
+      .then((result) => {
+        const current = result.find((x) => x.id === id);
+        if (current) {
+          setLine({ name: current.name });
+        }
+        setIsLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setIsLoading(false);
+      });
+  }, [id]);
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    putResearchLine(id, line)
+      .then(() => navigate(-1))
+      .catch(() => setError(true));
+  };
+
+  return (
+    <PageContainer name={name} isLoading={isLoading}>
+      <BackButton />
+      {!error ? (
+        <form className="form">
+          <div className="form-section">
+            <div className="formInput">
+              <label htmlFor="name">Nome</label>
+              <input
+                required
+                type="text"
+                name="name"
+                value={line.name}
+                onChange={(e) => setLine({ name: e.target.value })}
+                id="name"
+              />
+            </div>
+          </div>
+          <div className="form-section">
+            <div className="formInput">
+              <input type="submit" value={"Update"} onClick={handleSave} />
+            </div>
+          </div>
+        </form>
+      ) : (
+        <ErrorPage />
+      )}
+    </PageContainer>
+  );
+}

--- a/front/src/pages/researcher/profile.jsx
+++ b/front/src/pages/researcher/profile.jsx
@@ -1,0 +1,59 @@
+import { useParams, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import "../../styles/profile.scss";
+import PageContainer from "../../components/PageContainer";
+import BackButton from "../../components/BackButton";
+import ErrorPage from "../../components/error/Error";
+import jwt_decode from "jwt-decode";
+import { getResearcherById } from "../../api/researcher_service";
+
+export default function ResearcherProfile(){
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [researcher, setResearcher] = useState();
+    const [error, setError] = useState(false);
+    const [role, setRole] = useState();
+    const [isLoading, setIsLoading] = useState(true);
+    const [name] = useState(localStorage.getItem('name'));
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            setRole(decoded.role);
+        } catch(err){
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getResearcherById(id)
+            .then(res => { setResearcher(res); setIsLoading(false); })
+            .catch(()=> { setError(true); setIsLoading(false); });
+    }, [id]);
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            {!error && researcher && (
+                <div style={{display:'flex', flexDirection:'column', flexWrap:'wrap'}}>
+                    <div className="bar">
+                        <BackButton />
+                        {role === 'Administrator' && (
+                            <div className="options">
+                                <input type='button' className='option' value='Editar Pesquisador' onClick={()=>navigate('edit')} />
+                            </div>
+                        )}
+                    </div>
+                    <div className="card-label">Perfil pesquisador</div>
+                    <div className="studentCard">
+                        <p data-label="Nome">{`${researcher.firstName} ${researcher.lastName}`}</p>
+                        <p data-label="Email">{researcher.email}</p>
+                        <p data-label="CPF">{researcher.cpf}</p>
+                        <p data-label="Instituição">{researcher.institution}</p>
+                    </div>
+                </div>
+            )}
+            {error && <ErrorPage />}
+        </PageContainer>
+    );
+}

--- a/front/src/pages/researcher/researcherList.jsx
+++ b/front/src/pages/researcher/researcherList.jsx
@@ -14,6 +14,10 @@ export default function ResearcherList() {
     const [isLoading, setIsLoading] = useState(true)
     const [researchers, setResearchers] = useState([])
 
+    const detailsCallback = (id) => {
+        navigate(id)
+    }
+
     useEffect(() => {
         const roles = ['Administrator']
         const token = localStorage.getItem('token')
@@ -67,7 +71,7 @@ export default function ResearcherList() {
                 </div>
             </div>
             <BackButton />
-            <Table data={researchers} useOptions={true} detailsCallback={(id)=>navigate(`${id}`)} />
+            <Table data={researchers} useOptions={true} detailsCallback={detailsCallback} />
         </PageContainer>
     )
 }

--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -9,7 +9,7 @@ import { postResearchers, getResearcherById, putResearcherById } from "../../api
 import BackButton from "../../components/BackButton";
 import ErrorPage from "../../components/error/Error";
 import PageContainer from "../../components/PageContainer";
-import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE } from "../../enum_helpers";
+import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE, GENDER_ENUM } from "../../enum_helpers";
 import MultiSelect from "../../components/Multiselect";
 import { translateEnumValue } from "../../enum_helpers";
 import { isValidCPF } from "../../utils/cpf";
@@ -30,6 +30,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
         undergraduateArea: 1,
         institutionType: 1,
         scholarship: 1,
+        gender: 1,
     });
     const [projects, setProjects] = useState([]);
     const [role, setRole] = useState(localStorage.getItem('role'));
@@ -46,6 +47,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
         registration: "",
         registrationDate: '',
         status: 1,
+        gender: 1,
         entryDate: '',
         proficiency: false,
         undergraduateInstitution: "",
@@ -76,6 +78,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             scholarship: SCHOLARSHIP_TYPE.find((x) => x.name === student.scholarship).key,
                             institutionType: INSTITUTION_TYPE_ENUM.find((x) => x.name === student.institutionType).key,
                             status: STATUS_ENUM.find((x) => x.name === student.status).key,
+                            gender: GENDER_ENUM.find((x) => x.name === student.gender).key,
                         });
                         projectsId = student.projectId;
                         setOldValues({
@@ -83,6 +86,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             institutionType: student.institutionType,
                             scholarship: student.scholarship,
                             undergraduateArea: student.undergraduateArea,
+                            gender: student.gender,
                         });
                     })
                     .catch((error) => {
@@ -311,6 +315,30 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                                     <div className="formInput">
                                         <label htmlFor="registration">Matricula</label>
                                         <input required={true} type="text" name="registration" id="registration" value={student.registration} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                    </div>
+                                    <div className="formInput">
+                                        <Select
+                                            required={true}
+                                            defaultValue={oldValues.gender}
+                                            label="Sexo"
+                                            onSelect={(value) => changeStudentAttribute("gender", Number(value))}
+                                            name="gender"
+                                            options={GENDER_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                        />
+                                    </div>
+                                    <div className="formInput">
+                                        <Select
+                                            required={true}
+                                            defaultValue={oldValues.status}
+                                            label="Status"
+                                            onSelect={(value) => changeStudentAttribute("status", Number(value))}
+                                            name="status"
+                                            options={STATUS_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                        />
+                                    </div>
+                                    <div className="formInput">
+                                        <label htmlFor="proficiency">Proficiência em Inglês</label>
+                                        <input type="checkbox" name="proficiency" id="proficiency" checked={student.proficiency} onChange={(e) => changeStudentAttribute(e.target.name, e.target.checked)} />
                                     </div>
                                     <div className="formInput">
                                         <Select

--- a/front/src/pages/user/userList.jsx
+++ b/front/src/pages/user/userList.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import '../../styles/userList.scss';
+import Table from "../../components/Table/table";
+import { getUsers, deleteUser } from "../../api/user_service";
+import { useNavigate } from "react-router";
+import jwt_decode from "jwt-decode";
+import BackButton from "../../components/BackButton";
+import PageContainer from "../../components/PageContainer";
+import { translateEnumValue, ROLES_ENUM } from "../../enum_helpers";
+
+export default function UserList() {
+    const navigate = useNavigate();
+    const [name] = useState(localStorage.getItem('name'));
+    const [role, setRole] = useState(localStorage.getItem('role'));
+    const [users, setUsers] = useState([]);
+    const [tableData, setTableData] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            const decoded = jwt_decode(token);
+            if (decoded.role !== 'Administrator') {
+                navigate('/');
+            }
+            setRole(decoded.role);
+        } catch (error) {
+            navigate('/login');
+        }
+    }, [navigate]);
+
+    useEffect(() => {
+        getUsers()
+            .then(result => {
+                const list = result ?? [];
+                setUsers(list);
+                const mapped = list.map(u => ({
+                    Id: u.id,
+                    Nome: `${u.firstName} ${u.lastName}`,
+                    Email: u.email,
+                    Perfil: translateEnumValue(ROLES_ENUM, u.role)
+                }));
+                setTableData(mapped);
+                setIsLoading(false);
+            });
+    }, []);
+
+    const handleDelete = (id) => {
+        deleteUser(id).then(() => {
+            setUsers(users.filter(u => u.id !== id));
+            setTableData(tableData.filter(t => t.Id !== id));
+        });
+    };
+
+    const handleDetails = (id) => {
+        const user = users.find(u => u.id === id);
+        if (!user) return;
+        switch (user.role) {
+            case 'Student':
+                navigate(`/students/${id}/edit`);
+                break;
+            case 'Professor':
+                navigate(`/professors/${id}/edit`);
+                break;
+            case 'ExternalResearcher':
+                navigate(`/researchers/${id}`);
+                break;
+            default:
+                break;
+        }
+    };
+
+    return (
+        <PageContainer name={name} isLoading={isLoading}>
+            <div className="userBar">
+                <div className="left-bar">
+                    <div>
+                        <img src="student.png" alt="Users" height={"100rem"} />
+                    </div>
+                    <div className="title">Usuários</div>
+                </div>
+                <div className="right-bar">
+                    <div className="search">
+                        <input type="search" name="search" id="search" />
+                    </div>
+                    <div className="create-button">
+                        <button onClick={() => navigate('/user/add')}>Novo Usuário</button>
+                    </div>
+                </div>
+            </div>
+            <BackButton />
+            <Table data={tableData} useOptions={true} detailsCallback={handleDetails} deleteCallback={handleDelete} />
+        </PageContainer>
+    );
+}

--- a/front/src/pages/user/userUpdate.jsx
+++ b/front/src/pages/user/userUpdate.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import UserForm from './createUser';
+
+export default function UserUpdate(){
+    const { role } = useParams();
+    return <UserForm isUpdate={true} type={role} />;
+}

--- a/front/src/styles/courseList.scss
+++ b/front/src/styles/courseList.scss
@@ -1,0 +1,48 @@
+.courseBar {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .left-bar {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        flex-direction: row;
+
+        .title {
+            text-align: center;
+            font-size: xx-large;
+            font-weight: bolder;
+        }
+    }
+
+    .right-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        align-items: center;
+        flex-direction: row;
+        padding: 1rem;
+
+        button {
+            border-radius: 2rem;
+            padding: 1rem;
+            color: white;
+            margin: 0.5rem;
+            font-weight: bold;
+            background: #004AAD;
+        }
+
+        input {
+            visibility: hidden;
+            border-radius: 1rem;
+            text-align: center;
+            padding: 0.5rem;
+            color: #004AAD;
+            border: 2px solid #004AAD;
+        }
+    }
+}

--- a/front/src/styles/researchLineList.scss
+++ b/front/src/styles/researchLineList.scss
@@ -1,0 +1,48 @@
+.researchBar {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .left-bar {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        flex-direction: row;
+
+        .title {
+            text-align: center;
+            font-size: xx-large;
+            font-weight: bolder;
+        }
+    }
+
+    .right-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        align-items: center;
+        flex-direction: row;
+        padding: 1rem;
+
+        button {
+            border-radius: 2rem;
+            padding: 1rem;
+            color: white;
+            margin: 0.5rem;
+            font-weight: bold;
+            background: #004AAD;
+        }
+
+        input {
+            visibility: hidden;
+            border-radius: 1rem;
+            text-align: center;
+            padding: 0.5rem;
+            color: #004AAD;
+            border: 2px solid #004AAD;
+        }
+    }
+}

--- a/front/src/styles/userList.scss
+++ b/front/src/styles/userList.scss
@@ -1,0 +1,48 @@
+.userBar {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .left-bar {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        flex-direction: row;
+
+        .title {
+            text-align: center;
+            font-size: xx-large;
+            font-weight: bolder;
+        }
+    }
+
+    .right-bar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        align-items: center;
+        flex-direction: row;
+        padding: 1rem;
+
+        button {
+            border-radius: 2rem;
+            padding: 1rem;
+            color: white;
+            margin: 0.5rem;
+            font-weight: bold;
+            background: #004AAD;
+        }
+
+        input {
+            visibility: hidden;
+            border-radius: 1rem;
+            text-align: center;
+            padding: 0.5rem;
+            color: #004AAD;
+            border: 2px solid #004AAD;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix front test"
+  }
+}


### PR DESCRIPTION
## Summary
- add API helpers for Course endpoints
- implement React pages to list and manage courses
- wire new course pages in application routes and home navigation

## Testing
- `dotnet test backend/tests/Tests.csproj` *(fails: command not found)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a19b04948331b2ee27da6bac6d00