### PR TITLE
Add gender field

### DIFF
--- a/backend/Migrations/20250623185228_AddGenderColumn.cs
+++ b/backend/Migrations/20250623185228_AddGenderColumn.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace saga.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGenderColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Gender",
+                table: "Students",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "Students");
+        }
+    }
+}

--- a/backend/Migrations/ContexRepositoryModelSnapshot.cs
+++ b/backend/Migrations/ContexRepositoryModelSnapshot.cs
@@ -207,6 +207,9 @@ namespace saga.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 
+                    b.Property<int>("Gender")
+                        .HasColumnType("integer");
+
                     b.HasKey("Id");
 
                     b.HasIndex("ResearchLineId");

--- a/backend/Models/DTOs/Student/StudentDto.cs
+++ b/backend/Models/DTOs/Student/StudentDto.cs
@@ -15,6 +15,8 @@ namespace saga.Models.DTOs
 
         public StatusEnum Status { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public DateTime? EntryDate { get; set; }
 
         public DateTime? ProjectDefenceDate { get; set; }

--- a/backend/Models/DTOs/Student/StudentInfoDto.cs
+++ b/backend/Models/DTOs/Student/StudentInfoDto.cs
@@ -14,6 +14,8 @@ namespace saga.Models.DTOs
 
         public StatusEnum Status { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public DateTime? EntryDate { get; set; }
 
         public DateTime? ProjectDefenceDate { get; set; }

--- a/backend/Models/Entities/StudentEntity.cs
+++ b/backend/Models/Entities/StudentEntity.cs
@@ -37,6 +37,11 @@ namespace saga.Models.Entities
         public StatusEnum Status { get; set; }
 
         /// <summary>
+        /// The gender of the student.
+        /// </summary>
+        public GenderEnum Gender { get; set; }
+
+        /// <summary>
         /// The date on which the student entered the program.
         /// </summary>
         public DateTime? EntryDate { get; set; }

--- a/backend/Models/Enums/GenderEnum.cs
+++ b/backend/Models/Enums/GenderEnum.cs
@@ -1,0 +1,15 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace saga.Models.Enums
+{
+    public enum GenderEnum
+    {
+        Default,
+        [Name("Masculino")]
+        Male,
+        [Name("Feminino")]
+        Female,
+        [Name("Outro")]
+        Other
+    }
+}

--- a/backend/Models/Mapper/StudentMapper.cs
+++ b/backend/Models/Mapper/StudentMapper.cs
@@ -23,6 +23,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = dto.RegistrationDate?.ToUniversalTime(),
                 ProjectId = dto.ProjectId,
                 Status = dto.Status,
+                Gender = dto.Gender,
                 EntryDate = dto.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = dto.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = dto.ProjectQualificationDate?.ToUniversalTime(),
@@ -48,6 +49,7 @@ namespace saga.Models.Mapper
         {
             entityToUpdate.ProjectId = self.ProjectId;
             entityToUpdate.Status = self.Status;
+            entityToUpdate.Gender = self.Gender;
             entityToUpdate.EntryDate = self.EntryDate;
             entityToUpdate.ProjectDefenceDate = self.ProjectDefenceDate;
             entityToUpdate.ProjectQualificationDate = self.ProjectQualificationDate;
@@ -81,6 +83,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = self.RegistrationDate?.ToUniversalTime(),
                 ProjectId = self.ProjectId,
                 Status = self.Status,
+                Gender = self.Gender,
                 EntryDate = self.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = self.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = self.ProjectQualificationDate?.ToUniversalTime(),
@@ -111,6 +114,7 @@ namespace saga.Models.Mapper
                 RegistrationDate = self.RegistrationDate?.ToUniversalTime(),
                 ProjectId = self.ProjectId,
                 Status = self.Status,
+                Gender = self.Gender,
                 EntryDate = self.EntryDate?.ToUniversalTime(),
                 ProjectDefenceDate = self.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = self.ProjectQualificationDate?.ToUniversalTime(),

--- a/backend/tests/StudentServiceTests.cs
+++ b/backend/tests/StudentServiceTests.cs
@@ -32,7 +32,10 @@ public class StudentServiceTests : TestBase
             Email = "student@example.com",
             Cpf = "12345678901",
             Registration = "2023",
-            Role = RolesEnum.Student
+            Role = RolesEnum.Student,
+            Gender = GenderEnum.Male,
+            Status = StatusEnum.Active,
+            Proficiency = true
         };
 
         var created = await service.CreateStudentAsync(dto);
@@ -41,5 +44,8 @@ public class StudentServiceTests : TestBase
         var retrieved = await service.GetStudentAsync(created.Id);
         Assert.Equal("2023", retrieved.Registration);
         Assert.Equal("student@example.com", retrieved.Email);
+        Assert.Equal(GenderEnum.Male, retrieved.Gender);
+        Assert.Equal(StatusEnum.Active, retrieved.Status);
+        Assert.True(retrieved.Proficiency);
     }
 }

--- a/front/src/enum_helpers.js
+++ b/front/src/enum_helpers.js
@@ -13,6 +13,13 @@ export const AREA_ENUM = [
     { key: 2, name: "Graduated", translation: "Formado" },
     { key: 3, name: "Disconnected", translation: "Desconectado" },
   ];
+
+  export const GENDER_ENUM = [
+    { key: 0, name: "Default", translation: "Padrão" },
+    { key: 1, name: "Male", translation: "Masculino" },
+    { key: 2, name: "Female", translation: "Feminino" },
+    { key: 3, name: "Other", translation: "Outro" },
+  ];
   
   export const ROLES_ENUM = [
     { key: 0, name: "Default", translation: "Padrão" },

--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -9,7 +9,7 @@ import { postResearchers, getResearcherById, putResearcherById } from "../../api
 import BackButton from "../../components/BackButton";
 import ErrorPage from "../../components/error/Error";
 import PageContainer from "../../components/PageContainer";
-import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE } from "../../enum_helpers";
+import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE, GENDER_ENUM } from "../../enum_helpers";
 import MultiSelect from "../../components/Multiselect";
 import { translateEnumValue } from "../../enum_helpers";
 import { isValidCPF } from "../../utils/cpf";
@@ -30,6 +30,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
         undergraduateArea: 1,
         institutionType: 1,
         scholarship: 1,
+        gender: 1,
     });
     const [projects, setProjects] = useState([]);
     const [role, setRole] = useState(localStorage.getItem('role'));
@@ -46,6 +47,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
         registration: "",
         registrationDate: '',
         status: 1,
+        gender: 1,
         entryDate: '',
         proficiency: false,
         undergraduateInstitution: "",
@@ -76,6 +78,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             scholarship: SCHOLARSHIP_TYPE.find((x) => x.name === student.scholarship).key,
                             institutionType: INSTITUTION_TYPE_ENUM.find((x) => x.name === student.institutionType).key,
                             status: STATUS_ENUM.find((x) => x.name === student.status).key,
+                            gender: GENDER_ENUM.find((x) => x.name === student.gender).key,
                         });
                         projectsId = student.projectId;
                         setOldValues({
@@ -83,6 +86,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             institutionType: student.institutionType,
                             scholarship: student.scholarship,
                             undergraduateArea: student.undergraduateArea,
+                            gender: student.gender,
                         });
                     })
                     .catch((error) => {
@@ -311,6 +315,30 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                                     <div className="formInput">
                                         <label htmlFor="registration">Matricula</label>
                                         <input required={true} type="text" name="registration" id="registration" value={student.registration} onChange={(e) => changeStudentAttribute(e.target.name, e.target.value)} />
+                                    </div>
+                                    <div className="formInput">
+                                        <Select
+                                            required={true}
+                                            defaultValue={oldValues.gender}
+                                            label="Sexo"
+                                            onSelect={(value) => changeStudentAttribute("gender", Number(value))}
+                                            name="gender"
+                                            options={GENDER_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                        />
+                                    </div>
+                                    <div className="formInput">
+                                        <Select
+                                            required={true}
+                                            defaultValue={oldValues.status}
+                                            label="Status"
+                                            onSelect={(value) => changeStudentAttribute("status", Number(value))}
+                                            name="status"
+                                            options={STATUS_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                        />
+                                    </div>
+                                    <div className="formInput">
+                                        <label htmlFor="proficiency">Proficiência em Inglês</label>
+                                        <input type="checkbox" name="proficiency" id="proficiency" checked={student.proficiency} onChange={(e) => changeStudentAttribute(e.target.name, e.target.checked)} />
                                     </div>
                                     <div className="formInput">
                                         <Select


### PR DESCRIPTION
## Summary
- add new `GenderEnum` and column migration
- include gender property in Student entity & DTOs
- map gender data
- render gender, status & proficiency fields in frontend
- extend StudentService test for new fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a17825e883318deddbdba6f76801