### PR TITLE
Add gender support for students

### DIFF
--- a/backend/Migrations/20230630163729_AddTables.Designer.cs
+++ b/backend/Migrations/20230630163729_AddTables.Designer.cs
@@ -282,6 +282,9 @@ namespace saga.Migrations
                     b.Property<string>("CPF")
                         .HasColumnType("text");
 
+                    b.Property<int>("Gender")
+                        .HasColumnType("integer");
+
                     b.Property<DateTime?>("DateOfBirth")
                         .HasColumnType("timestamp with time zone");
 

--- a/backend/Migrations/20230630163729_AddTables.cs
+++ b/backend/Migrations/20230630163729_AddTables.cs
@@ -226,6 +226,7 @@ namespace saga.Migrations
                     ProjectQualificationDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
                     Proficiency = table.Column<bool>(type: "boolean", nullable: false),
                     CPF = table.Column<string>(type: "text", nullable: true),
+                    Gender = table.Column<int>(type: "integer", nullable: false),
                     UndergraduateInstitution = table.Column<string>(type: "text", nullable: true),
                     InstitutionType = table.Column<int>(type: "integer", nullable: false),
                     UndergraduateCourse = table.Column<string>(type: "text", nullable: true),

--- a/backend/Migrations/ContexRepositoryModelSnapshot.cs
+++ b/backend/Migrations/ContexRepositoryModelSnapshot.cs
@@ -279,6 +279,9 @@ namespace saga.Migrations
                     b.Property<string>("CPF")
                         .HasColumnType("text");
 
+                    b.Property<int>("Gender")
+                        .HasColumnType("integer");
+
                     b.Property<DateTime?>("DateOfBirth")
                         .HasColumnType("timestamp with time zone");
 

--- a/backend/Models/DTOs/Student/StudentCsvDto.cs
+++ b/backend/Models/DTOs/Student/StudentCsvDto.cs
@@ -35,6 +35,9 @@ namespace saga.Models.DTOs
         [Optional]
         public string? Proficiency { get; set; }
 
+        [Name("Sexo")]
+        public GenderEnum Gender { get; set; }
+
         [Name("Instituição de Formação")]
         public string? UndergraduateInstitution { get; set; }
 

--- a/backend/Models/DTOs/Student/StudentDto.cs
+++ b/backend/Models/DTOs/Student/StudentDto.cs
@@ -23,6 +23,8 @@ namespace saga.Models.DTOs
 
         public bool Proficiency { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public string? UndergraduateInstitution { get; set; }
 
         public InstitutionTypeEnum InstitutionType { get; set; }

--- a/backend/Models/DTOs/Student/StudentInfoDto.cs
+++ b/backend/Models/DTOs/Student/StudentInfoDto.cs
@@ -22,6 +22,8 @@ namespace saga.Models.DTOs
 
         public bool Proficiency { get; set; }
 
+        public GenderEnum Gender { get; set; }
+
         public string? UndergraduateInstitution { get; set; }
 
         public InstitutionTypeEnum InstitutionType { get; set; }

--- a/backend/Models/Entities/StudentEntity.cs
+++ b/backend/Models/Entities/StudentEntity.cs
@@ -62,6 +62,11 @@ namespace saga.Models.Entities
         public string? CPF { get; set; }
 
         /// <summary>
+        /// The gender of the student.
+        /// </summary>
+        public GenderEnum Gender { get; set; }
+
+        /// <summary>
         /// The name of the undergraduate institution the student attended.
         /// </summary>
         public string? UndergraduateInstitution { get; set; }

--- a/backend/Models/Enums/GenderEnum.cs
+++ b/backend/Models/Enums/GenderEnum.cs
@@ -1,0 +1,15 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace saga.Models.Enums
+{
+    public enum GenderEnum
+    {
+        Default,
+        [Name("Masculino")]
+        Male,
+        [Name("Feminino")]
+        Female,
+        [Name("Outro")]
+        Other
+    }
+}

--- a/backend/Models/Mapper/StudentMapper.cs
+++ b/backend/Models/Mapper/StudentMapper.cs
@@ -27,6 +27,7 @@ namespace saga.Models.Mapper
                 ProjectDefenceDate = dto.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = dto.ProjectQualificationDate?.ToUniversalTime(),
                 Proficiency = dto.Proficiency,
+                Gender = dto.Gender,
                 UndergraduateInstitution = dto.UndergraduateInstitution,
                 InstitutionType = dto.InstitutionType,
                 UndergraduateCourse = dto.UndergraduateCourse,
@@ -52,6 +53,7 @@ namespace saga.Models.Mapper
             entityToUpdate.ProjectDefenceDate = self.ProjectDefenceDate;
             entityToUpdate.ProjectQualificationDate = self.ProjectQualificationDate;
             entityToUpdate.Proficiency = self.Proficiency;
+            entityToUpdate.Gender = self.Gender;
             entityToUpdate.UndergraduateInstitution = self.UndergraduateInstitution;
             entityToUpdate.InstitutionType = self.InstitutionType;
             entityToUpdate.UndergraduateCourse = self.UndergraduateCourse;
@@ -85,6 +87,7 @@ namespace saga.Models.Mapper
                 ProjectDefenceDate = self.ProjectDefenceDate?.ToUniversalTime(),
                 ProjectQualificationDate = self.ProjectQualificationDate?.ToUniversalTime(),
                 Proficiency = self.Proficiency,
+                Gender = self.Gender,
                 UndergraduateInstitution = self.UndergraduateInstitution,
                 InstitutionType = self.InstitutionType,
                 UndergraduateCourse = self.UndergraduateCourse,
@@ -121,7 +124,8 @@ namespace saga.Models.Mapper
                 GraduationYear = self.GraduationYear,
                 UndergraduateArea = self.UndergraduateArea,
                 DateOfBirth = self.DateOfBirth?.ToUniversalTime(),
-                Scholarship = self.Scholarship
+                Scholarship = self.Scholarship,
+                Gender = self.Gender
             };
             return self?.User is null ? entity : entity.AddUserDto(self.User);
         }
@@ -142,6 +146,7 @@ namespace saga.Models.Mapper
                 ProjectDefenceDate = csv.ProjectDefenceDate.Parse()?.ToUniversalTime(),
                 ProjectQualificationDate = csv.ProjectQualificationDate.Parse()?.ToUniversalTime(),
                 Proficiency = csv.Proficiency?.ToLower() == "sim",
+                Gender = csv.Gender,
                 UndergraduateInstitution = csv.UndergraduateInstitution,
                 InstitutionType = (InstitutionTypeEnum)csv.InstitutionType,
                 UndergraduateCourse = csv.UndergraduateCourse,

--- a/backend/tests/StudentServiceTests.cs
+++ b/backend/tests/StudentServiceTests.cs
@@ -32,7 +32,8 @@ public class StudentServiceTests : TestBase
             Email = "student@example.com",
             Cpf = "12345678901",
             Registration = "2023",
-            Role = RolesEnum.Student
+            Role = RolesEnum.Student,
+            Gender = GenderEnum.Male
         };
 
         var created = await service.CreateStudentAsync(dto);

--- a/front/src/enum_helpers.js
+++ b/front/src/enum_helpers.js
@@ -13,6 +13,13 @@ export const AREA_ENUM = [
     { key: 2, name: "Graduated", translation: "Formado" },
     { key: 3, name: "Disconnected", translation: "Desconectado" },
   ];
+
+  export const GENDER_ENUM = [
+    { key: 0, name: "Default", translation: "Padrão" },
+    { key: 1, name: "Male", translation: "Masculino" },
+    { key: 2, name: "Female", translation: "Feminino" },
+    { key: 3, name: "Other", translation: "Outro" },
+  ];
   
   export const ROLES_ENUM = [
     { key: 0, name: "Default", translation: "Padrão" },

--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -9,7 +9,7 @@ import { postResearchers, getResearcherById, putResearcherById } from "../../api
 import BackButton from "../../components/BackButton";
 import ErrorPage from "../../components/error/Error";
 import PageContainer from "../../components/PageContainer";
-import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE } from "../../enum_helpers";
+import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE, GENDER_ENUM } from "../../enum_helpers";
 import MultiSelect from "../../components/Multiselect";
 import { translateEnumValue } from "../../enum_helpers";
 import { isValidCPF } from "../../utils/cpf";
@@ -27,6 +27,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
     const [errorMessage, setErrorMessage] = useState(undefined);
     const [oldValues, setOldValues] = useState({
         status: 1,
+        gender: 1,
         undergraduateArea: 1,
         institutionType: 1,
         scholarship: 1,
@@ -46,6 +47,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
         registration: "",
         registrationDate: '',
         status: 1,
+        gender: 1,
         entryDate: '',
         proficiency: false,
         undergraduateInstitution: "",
@@ -76,6 +78,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             scholarship: SCHOLARSHIP_TYPE.find((x) => x.name === student.scholarship).key,
                             institutionType: INSTITUTION_TYPE_ENUM.find((x) => x.name === student.institutionType).key,
                             status: STATUS_ENUM.find((x) => x.name === student.status).key,
+                            gender: GENDER_ENUM.find((x) => x.name === student.gender).key,
                         });
                         projectsId = student.projectId;
                         setOldValues({
@@ -83,6 +86,7 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                             institutionType: student.institutionType,
                             scholarship: student.scholarship,
                             undergraduateArea: student.undergraduateArea,
+                            gender: student.gender,
                         });
                     })
                     .catch((error) => {
@@ -297,12 +301,23 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                         </div>
                         <div className="form-section">
                             <div className="formInput">
-                                <label htmlFor="email">Email</label>
-                                <input required={true} type="email" name="email" id="email" value={user.email} onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
+                                <label htmlFor="registrationCpf">CPF</label>
+                                <input required={true} type="text" name="cpf" value={user.cpf} id="registrationCpf" onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
                             </div>
                             <div className="formInput">
-                                <label htmlFor="cpf">CPF</label>
-                                <input required={true} type="text" name="cpf" value={user.cpf} id="cpf" onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
+                                <Select
+                                    required={true}
+                                    defaultValue={oldValues.gender}
+                                    className="formInput"
+                                    options={GENDER_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                    onSelect={(value) => changeStudentAttribute("gender", Number(value))}
+                                    label="Sexo"
+                                    name="gender"
+                                />
+                            </div>
+                            <div className="formInput">
+                                <label htmlFor="email">Email</label>
+                                <input required={true} type="email" name="email" id="email" value={user.email} onChange={(e) => changeUserAtribute(e.target.name, e.target.value)} />
                             </div>
                         </div>
                         {userType === "Estudante" && (
@@ -321,6 +336,20 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                                             name="scholarship"
                                             options={SCHOLARSHIP_TYPE.map((item) => ({ value: item.key, label: item.translation }))}
                                         />
+                                    </div>
+                                    <div className="formInput">
+                                        <Select
+                                            required={true}
+                                            defaultValue={oldValues.status}
+                                            label={"Status"}
+                                            onSelect={(value) => changeStudentAttribute("status", Number(value))}
+                                            name="status"
+                                            options={STATUS_ENUM.map((item) => ({ value: item.key, label: item.translation }))}
+                                        />
+                                    </div>
+                                    <div className="formInput">
+                                        <label htmlFor="proficiency">Proficiência em Inglês</label>
+                                        <input type="checkbox" name="proficiency" id="proficiency" checked={student.proficiency} onChange={(e) => changeStudentAttribute(e.target.name, e.target.checked)} />
                                     </div>
                                     <div className="formInput">
                                         <label htmlFor="registrationDate">Data de Matrícula</label>


### PR DESCRIPTION
## Summary
- create `GenderEnum` and reference it from `StudentEntity`
- expose gender on Student DTOs and mapper
- update EF migrations for the new column
- extend `createUser` page with gender, status and proficiency fields
- provide gender translations for the frontend
- adjust tests for new property

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a14af824833194f8d4ec5da218e6