### PR TITLE
Refactor email templates

### DIFF
--- a/backend/Infrastructure/Jobs/StudentsFinishing.cs
+++ b/backend/Infrastructure/Jobs/StudentsFinishing.cs
@@ -47,13 +47,9 @@ namespace Infrastructure.Jobs
 
         private async Task NotifyProfessorAsync(IGrouping<Guid, OrientationEntity> groupedOrientations, Dictionary<Guid, StudentEntity> studentInfo)
         {
-            string emailSubject = "Próximas Defesas de Alunos";
-            var body = new StringBuilder();
-            body.AppendLine("Os seguintes estudantes estão concluindo o curso:");
-
-            string emailBody = EmailTemplates.EmailTemplates.StudentsFinishingFromProfessorEmailTemplate(groupedOrientations, studentInfo);
+            var content = EmailTemplates.EmailTemplates.StudentsFinishingFromProfessorEmailTemplate(groupedOrientations, studentInfo);
             string professorEmail = groupedOrientations?.FirstOrDefault()?.Professor?.Email;
-            await _emailSender.SendEmail(professorEmail, emailSubject, emailBody).ConfigureAwait(false);
+            await _emailSender.SendEmail(professorEmail, content.Subject, content.Body).ConfigureAwait(false);
         }
 
         private async Task NotifyStudentAsync(StudentEntity student)
@@ -70,10 +66,9 @@ namespace Infrastructure.Jobs
             }
 
             string defenseTypeText = string.Join(" e ", defenseTypes);
-            string emailSubject = $"Data limite de {defenseTypeText} se aproximando.";
-            string emailBody = EmailTemplates.EmailTemplates.UpcomingDefenseEmailTemplate(student.User?.FirstName, defenseTypeText, student.ProjectQualificationDate, student.ProjectDefenceDate);
+            var content = EmailTemplates.EmailTemplates.UpcomingDefenseEmailTemplate(student.User?.FirstName, defenseTypeText, student.ProjectQualificationDate, student.ProjectDefenceDate);
 
-            await _emailSender.SendEmail(student.User.Email, emailSubject, emailBody).ConfigureAwait(false);
+            await _emailSender.SendEmail(student.User.Email, content.Subject, content.Body).ConfigureAwait(false);
         }
 
         private async Task UpdateStudentAsync(StudentEntity student)

--- a/backend/Infrastructure/Providers/EmailTemplates.cs
+++ b/backend/Infrastructure/Providers/EmailTemplates.cs
@@ -3,58 +3,87 @@ using saga.Models.Entities;
 
 namespace Infrastructure.EmailTemplates
 {
+    public record EmailContent(string Subject, string Body);
+
+    public enum EmailLanguage
+    {
+        Pt,
+        En
+    }
+
     public static class EmailTemplates
     {
-        public static string WelcomeEmailTemplate(string resetPasswordPath, string token)
+        public static EmailContent WelcomeEmailTemplate(string resetPasswordPath, string token, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Bem-vindo(a) à Pós-Graduação do CEFET RJ!</p>
-                            <p>Para acessar sua conta, por favor, defina sua senha clicando no seguinte link:</p>
-                            <p><a href=""{resetPasswordPath}?token={token}"">{resetPasswordPath}?token={token}</a></p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? "Account Created" : "Sua conta foi criada";
+            string greeting = language == EmailLanguage.En ? "Welcome to the CEFET RJ Postgraduate Program!" : "Bem-vindo(a) à Pós-Graduação do CEFET RJ!";
+            string instruction = language == EmailLanguage.En ? "To access your account, please set your password using the link below:" : "Para acessar sua conta, por favor, defina sua senha clicando no seguinte link:";
+            string body = $"<html><body style='font-family: Arial, sans-serif;'>" +
+                         $"<p>{greeting}</p>" +
+                         $"<p>{instruction}</p>" +
+                         $"<p><a href='{resetPasswordPath}?token={token}'>{resetPasswordPath}?token={token}</a></p>" +
+                         "<br/>" +
+                         $"<p>{signature}</p>" +
+                         "</body></html>";
+            return new EmailContent(subject, body);
         }
 
-        public static string ResetPasswordEmailTemplate(string resetPasswordPath, string token)
+        public static EmailContent ResetPasswordEmailTemplate(string resetPasswordPath, string token, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Você solicitou a redefinição da sua senha. Por favor, clique no seguinte link para redefinir sua senha:</p>
-                            <p><a href=""{resetPasswordPath}?token={token}"">{resetPasswordPath}?token={token}</a></p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? "Password Reset" : "Alteração de senha";
+            string message = language == EmailLanguage.En ? "You requested a password reset. Click the link below:" : "Você solicitou a redefinição da sua senha. Por favor, clique no seguinte link para redefinir sua senha:";
+            string body = $"<html><body style='font-family: Arial, sans-serif;'>" +
+                         $"<p>{message}</p>" +
+                         $"<p><a href='{resetPasswordPath}?token={token}'>{resetPasswordPath}?token={token}</a></p>" +
+                         "<br/>" +
+                         $"<p>{signature}</p>" +
+                         "</body></html>";
+            return new EmailContent(subject, body);
         }
 
-        public static string UpcomingDefenseEmailTemplate(string? firstName, string defenseTypeText, DateTime? qualificationDate, DateTime? defenseDate)
+        public static EmailContent UpcomingDefenseEmailTemplate(string? firstName, string defenseTypeText, DateTime? qualificationDate, DateTime? defenseDate, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
-            return $@"<html>
-                        <body>
-                            <p>Prezado(a) {firstName},</p>
-                            <p>Este é um lembrete de que a data da sua {defenseTypeText} está se aproximando. Por favor, certifique-se de se preparar e estar pronto(a) para a sua apresentação.</p>
-                            <p>Se tiver alguma dúvida ou precisar de ajuda, sinta-se à vontade para entrar em contato com o seu orientador.</p>
-                            <p>Se você precisar de mais tempo para se preparar adequadamente, pode solicitar uma prorrogação entrando em contato com o seu orientador acadêmico.</p>
-                            <p>Data da sua Qualificação: {qualificationDate}</p>
-                            <p>Data da sua Defesa: {defenseDate}</p>
-                            <br>
-                            <p>Atenciosamente,</p>
-                            <p>A Equipe Acadêmica</p>
-                        </body>
-                    </html>";
+            string subject = language == EmailLanguage.En ? $"Upcoming {defenseTypeText} deadline" : $"Data limite de {defenseTypeText} se aproximando.";
+            var body = new StringBuilder();
+            body.Append("<html><body style='font-family: Arial, sans-serif;'>");
+            if (language == EmailLanguage.En)
+            {
+                body.Append($"<p>Dear {firstName},</p>");
+                body.Append($"<p>This is a reminder that your {defenseTypeText} date is approaching. Please be prepared for your presentation.</p>");
+                body.Append("<p>If you have any questions or need help, contact your advisor.</p>");
+                body.Append("<p>If you need more time, you can request an extension through your academic advisor.</p>");
+                body.Append($"<p>Qualification Date: {qualificationDate}</p>");
+                body.Append($"<p>Defense Date: {defenseDate}</p>");
+            }
+            else
+            {
+                body.Append($"<p>Prezado(a) {firstName},</p>");
+                body.Append($"<p>Este é um lembrete de que a data da sua {defenseTypeText} está se aproximando. Por favor, certifique-se de se preparar e estar pronto(a) para a sua apresentação.</p>");
+                body.Append("<p>Se tiver alguma dúvida ou precisar de ajuda, sinta-se à vontade para entrar em contato com o seu orientador.</p>");
+                body.Append("<p>Se você precisar de mais tempo para se preparar adequadamente, pode solicitar uma prorrogação entrando em contato com o seu orientador acadêmico.</p>");
+                body.Append($"<p>Data da sua Qualificação: {qualificationDate}</p>");
+                body.Append($"<p>Data da sua Defesa: {defenseDate}</p>");
+            }
+            body.Append("<br/>");
+            body.Append($"<p>{signature}</p>");
+            body.Append("</body></html>");
+            return new EmailContent(subject, body.ToString());
         }
 
-        public static string StudentsFinishingFromProfessorEmailTemplate(IGrouping<Guid, OrientationEntity> orientations, Dictionary<Guid, StudentEntity> students)
+        public static EmailContent StudentsFinishingFromProfessorEmailTemplate(IGrouping<Guid, OrientationEntity> orientations, Dictionary<Guid, StudentEntity> students, string signature = "A Equipe Acadêmica", EmailLanguage language = EmailLanguage.Pt)
         {
+            string subject = language == EmailLanguage.En ? "Upcoming Student Defenses" : "Próximas Defesas de Alunos";
             var body = new StringBuilder();
 
-            body.AppendLine("Os seguintes estudantes estão concluindo o curso:");
-            body.AppendLine("<table>");
+            body.AppendLine("<html><body style='font-family: Arial, sans-serif;'>");
+            body.AppendLine(language == EmailLanguage.En ? "<p>The following students are finishing the course:</p>" : "<p>Os seguintes estudantes estão concluindo o curso:</p>");
+            body.AppendLine("<table style='border-collapse: collapse; width: 100%;'>");
             body.AppendLine("<tr>");
-            body.AppendLine("<th>Nome</th>");
-            body.AppendLine("<th>Sobrenome</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>First Name</th>" : "<th>Nome</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Last Name</th>" : "<th>Sobrenome</th>");
             body.AppendLine("<th>Email</th>");
-            body.AppendLine("<th>Data de Defesa</th>");
-            body.AppendLine("<th>Data de Qualificação</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Defense Date</th>" : "<th>Data de Defesa</th>");
+            body.AppendLine(language == EmailLanguage.En ? "<th>Qualification Date</th>" : "<th>Data de Qualificação</th>");
             body.AppendLine("</tr>");
 
             foreach (var orientation in orientations)
@@ -72,7 +101,10 @@ namespace Infrastructure.EmailTemplates
             }
 
             body.AppendLine("</table>");
-            return body.ToString();
+            body.AppendLine("<br/>");
+            body.AppendLine($"<p>{signature}</p>");
+            body.AppendLine("</body></html>");
+            return new EmailContent(subject, body.ToString());
         }
     }
 }

--- a/backend/Services/UserService.cs
+++ b/backend/Services/UserService.cs
@@ -48,9 +48,8 @@ namespace saga.Services
             }
             var user = await _repository.User.AddAsync(userDto.ToUserEntity());
             var token = _tokenProvider.GenerateResetPasswordJwt(user, TimeSpan.FromDays(7));
-            string emailSubject = "Sua conta foi criada";
-            string emailBody = EmailTemplates.WelcomeEmailTemplate(userDto.ResetPasswordPath, token);
-            await _emailSender.SendEmail(userDto.Email, emailSubject, emailBody).ConfigureAwait(false);
+            var content = EmailTemplates.WelcomeEmailTemplate(userDto.ResetPasswordPath, token);
+            await _emailSender.SendEmail(userDto.Email, content.Subject, content.Body).ConfigureAwait(false);
             return user;
         }
 
@@ -60,9 +59,8 @@ namespace saga.Services
             var user = await _repository.User.GetUserByEmail(request.Email) ?? throw new ArgumentException($"User with email {request.Email} not found.");
 
             var token = _tokenProvider.GenerateResetPasswordJwt(user, TimeSpan.FromMinutes(30));
-            string emailSubject = "Alteração de senha";
-            string emailBody = EmailTemplates.ResetPasswordEmailTemplate(request.ResetPasswordPath, token);
-            await _emailSender.SendEmail(request.Email, emailSubject, emailBody).ConfigureAwait(false);
+            var resetContent = EmailTemplates.ResetPasswordEmailTemplate(request.ResetPasswordPath, token);
+            await _emailSender.SendEmail(request.Email, resetContent.Subject, resetContent.Body).ConfigureAwait(false);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- refactor `EmailTemplates.cs` to return subject/body pairs
- include simple styling, subject text and signature placeholders
- update `UserService` and `StudentsFinishing` job to use new API

## Testing
- `dotnet build saga.csproj -v minimal`
- `dotnet test tests/Tests.csproj -v minimal` *(fails: StudentServiceTests etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859a19790608331bc7cfd4aaa5399dc