### PR TITLE
Fix clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before you begin, ensure that you have the following prerequisites installed on 
 3. Run the following command to clone the repository:
 
    ```bash
-   git clone git@github.com:MLRG-CEFET-RJ/gerdisc.git
+   git clone git@github.com:radhanama/saga.git
    ```
 
 4. Wait for the repository to be cloned to your local machine.


### PR DESCRIPTION
## Summary
- point README clone command at the saga repo

## Testing
- `dotnet test backend/tests/Tests.csproj` *(fails: `dotnet` not found)*
- `npm test --silent -- --watchAll=false` in `front` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a194ed048331bf5259a1814f0c48