### PR TITLE
Display API error messages

### DIFF
--- a/front/src/api/_api.js
+++ b/front/src/api/_api.js
@@ -26,6 +26,12 @@ api.interceptors.request.use(
         localStorage.removeItem('role')
       }
       return response
+    },
+    (error)=>{
+      if(error.response){
+        return Promise.reject(error.response.data)
+      }
+      return Promise.reject({ message: error.message })
     }
   )
 

--- a/front/src/components/error/InlineError.jsx
+++ b/front/src/components/error/InlineError.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import './inlineError.scss';
+
+const InlineError = ({ message }) => {
+  if (!message) return null;
+  return <div className="inline-error">{message}</div>;
+};
+
+export default InlineError;

--- a/front/src/components/error/inlineError.scss
+++ b/front/src/components/error/inlineError.scss
@@ -1,0 +1,4 @@
+.inline-error {
+  color: red;
+  margin-top: 0.5rem;
+}

--- a/front/src/pages/login.jsx
+++ b/front/src/pages/login.jsx
@@ -3,6 +3,7 @@ import '../styles/login.scss';
 import { useNavigate } from 'react-router-dom';
 import { Login as login, ForgotPassword as forgotPassword } from '../api/user_service';
 import jwt_decode from 'jwt-decode';
+import InlineError from '../components/error/InlineError';
 
 export default function Login() {
   const navigate = useNavigate();
@@ -36,8 +37,9 @@ export default function Login() {
           setError('login failed');
         }
       })
-      .catch(() => {
-        setError('login failed');
+      .catch((err) => {
+        const message = err?.message || 'login failed';
+        setError(message);
       });
   };
 
@@ -98,7 +100,7 @@ export default function Login() {
               onChange={(e) => setPassword(e.target.value)}
             />
             <input type="submit" id="submit" value={'Login'} onClick={handleSubmit} />
-            {error && <p> {error} </p>}
+            <InlineError message={error} />
             <button id="forgotPassword" onClick={handleForgotPassword}>
               Esqueceu a senha?
             </button>

--- a/front/src/pages/research/createResearch.jsx
+++ b/front/src/pages/research/createResearch.jsx
@@ -7,7 +7,7 @@ import BackButton from "../../components/BackButton";
 import { getStudentById } from "../../api/student_service";
 import { getProjectById } from "../../api/project_service";
 import { getResearchers } from "../../api/researcher_service";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { postResearch } from "../../api/research_service";
 
@@ -93,6 +93,7 @@ export default function ResearchForm() {
       setTimeout(() => navigate(-1), 1000);
     } catch (err) {
       setError(true);
+      setErrorMessage(err?.message || 'Erro ao criar dissertação');
     }
   };
 
@@ -139,7 +140,7 @@ export default function ResearchForm() {
         </div>
       )}
       {success && <div className="success">Dissertação criada com sucesso</div>}
-      {error && <ErrorPage errorMessage={errorMessage} />}
+      {error && <InlineError message={errorMessage} />}
     </PageContainer>
   );
 }

--- a/front/src/pages/research/researchList.jsx
+++ b/front/src/pages/research/researchList.jsx
@@ -5,7 +5,7 @@ import { getResearch } from "../../api/research_service";
 import { useNavigate } from "react-router";
 import jwt_decode from "jwt-decode";
 import BackButton from "../../components/BackButton";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 
 export default function ResearchList() {
@@ -14,6 +14,7 @@ export default function ResearchList() {
   const [role, setRole] = useState(localStorage.getItem("role"));
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const [researches, setResearches] = useState([]);
 
   useEffect(() => {
@@ -52,6 +53,7 @@ export default function ResearchList() {
       .catch((error) => {
         console.log(error);
         setError(true);
+        setErrorMessage(error?.message || 'Erro ao carregar dissertações');
         setIsLoading(false);
       });
   }, [setResearches, setIsLoading]);
@@ -76,7 +78,7 @@ export default function ResearchList() {
           <Table data={researches} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
         </>
       ) : (
-        <ErrorPage />
+        <InlineError message={errorMessage} />
       )}
     </PageContainer>
   );

--- a/front/src/pages/research/updateResearch.jsx
+++ b/front/src/pages/research/updateResearch.jsx
@@ -6,7 +6,7 @@ import Select from "../../components/select";
 import BackButton from "../../components/BackButton";
 import { getProjectById } from "../../api/project_service";
 import { getResearchers } from "../../api/researcher_service";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { getResearchById, putResearch } from "../../api/research_service";
 
@@ -86,6 +86,7 @@ export default function ResearchUpdate() {
       setTimeout(() => navigate(-1), 1000);
     } catch (err) {
       setError(true);
+      setErrorMessage(err?.message || 'Erro ao atualizar dissertação');
     }
   };
 
@@ -126,7 +127,7 @@ export default function ResearchUpdate() {
         </div>
       )}
       {success && <div className="success">Dissertação atualizada com sucesso</div>}
-      {error && <ErrorPage errorMessage={errorMessage} />}
+      {error && <InlineError message={errorMessage} />}
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- show API error text via axios interceptor
- add new `InlineError` component
- use inline error display on login and research pages

## Testing
- `npm install` *(fails: node-sass build error)*

------
https://chatgpt.com/codex/tasks/task_e_6859a19390e48331a8d643958068a9ac