### PR TITLE
Add backend update/delete tests

### DIFF
--- a/backend/tests/CourseServiceTests.cs
+++ b/backend/tests/CourseServiceTests.cs
@@ -27,4 +27,51 @@ public class CourseServiceTests : TestBase
         Assert.Equal("Algorithms", retrieved.Name);
         Assert.Equal("CS101", retrieved.CourseUnique);
     }
+
+    [Fact]
+    public async Task UpdateCourse()
+    {
+        var logger = new Mock<ILogger<CourseService>>();
+        var service = new CourseService(Repository, logger.Object);
+
+        var created = await service.CreateCourseAsync(new CourseDto
+        {
+            Name = "Algorithms",
+            CourseUnique = "CS101",
+            Credits = 4
+        });
+
+        var updated = await service.UpdateCourseAsync(created.Id!.Value, new CourseDto
+        {
+            Name = "Data Structures",
+            CourseUnique = "CS102",
+            Credits = 3
+        });
+
+        Assert.Equal("Data Structures", updated.Name);
+        Assert.Equal("CS102", updated.CourseUnique);
+
+        var retrieved = await service.GetCourseAsync(created.Id.Value);
+        Assert.Equal("Data Structures", retrieved.Name);
+        Assert.Equal("CS102", retrieved.CourseUnique);
+    }
+
+    [Fact]
+    public async Task DeleteCourse()
+    {
+        var logger = new Mock<ILogger<CourseService>>();
+        var service = new CourseService(Repository, logger.Object);
+
+        var created = await service.CreateCourseAsync(new CourseDto
+        {
+            Name = "Algorithms",
+            CourseUnique = "CS101",
+            Credits = 4
+        });
+
+        await service.DeleteCourseAsync(created.Id!.Value);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.GetCourseAsync(created.Id.Value));
+    }
 }

--- a/backend/tests/ProjectServiceTests.cs
+++ b/backend/tests/ProjectServiceTests.cs
@@ -30,4 +30,56 @@ public class ProjectServiceTests : TestBase
         Assert.Equal("ProjectX", retrieved.Name);
         Assert.Equal(researchLine.Id, retrieved.ResearchLineId);
     }
+
+    [Fact]
+    public async Task UpdateProject()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var logger = new Mock<ILogger<ProjectService>>();
+        var service = new ProjectService(Repository, logger.Object);
+
+        var created = await service.CreateProjectAsync(new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectX",
+            Status = ProjectStatusEnum.Active,
+            ProfessorIds = new List<string>()
+        });
+
+        var updated = await service.UpdateProjectAsync(created.Id!.Value, new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectY",
+            Status = ProjectStatusEnum.Closed,
+            ProfessorIds = new List<string>()
+        });
+
+        Assert.Equal(ProjectStatusEnum.Closed, updated.Status);
+        Assert.Equal("ProjectY", updated.Name);
+
+        var retrieved = await service.GetProjectAsync(created.Id.Value);
+        Assert.Equal(ProjectStatusEnum.Closed, retrieved.Status);
+        Assert.Equal("ProjectY", retrieved.Name);
+    }
+
+    [Fact]
+    public async Task DeleteProject()
+    {
+        var researchLine = await Repository.ResearchLine.AddAsync(new ResearchLineEntity { Name = "AI" });
+        var logger = new Mock<ILogger<ProjectService>>();
+        var service = new ProjectService(Repository, logger.Object);
+
+        var created = await service.CreateProjectAsync(new ProjectDto
+        {
+            ResearchLineId = researchLine.Id,
+            Name = "ProjectX",
+            Status = ProjectStatusEnum.Active,
+            ProfessorIds = new List<string>()
+        });
+
+        await service.DeleteProjectAsync(created.Id!.Value);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.GetProjectAsync(created.Id.Value));
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix front test"
+  }
+}


### PR DESCRIPTION
## Summary
- cover update and delete logic for CourseService
- cover update and delete logic for ProjectService
- enable running frontend tests via `npm test`

## Testing
- `dotnet test backend/tests/Tests.csproj`
- `npm --prefix front test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a192b0e88331bf30b001d0f0c5c2