### PR TITLE
Add logout option and improve auth checks

### DIFF
--- a/front/src/components/PageContainer.jsx
+++ b/front/src/components/PageContainer.jsx
@@ -12,6 +12,10 @@ export default function PageContainer({ children, name, isLoading }) {
     const navigate = useNavigate()
     useEffect(() => {
         const token = localStorage.getItem('token')
+        if (!token) {
+            navigate('/login')
+            return
+        }
         try {
             const decoded = jwt_decode(token)
             if (decoded.exp < (Date.now()/1000)) {

--- a/front/src/components/header.jsx
+++ b/front/src/components/header.jsx
@@ -4,6 +4,14 @@ import '../styles/header.scss'
 
 export default function Header({ name }) {
     const navigate = useNavigate()
+
+    const handleLogout = () => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        localStorage.removeItem('name');
+        navigate('/login');
+    }
+
     return (
         <>
             <div className={"header"}>
@@ -13,6 +21,7 @@ export default function Header({ name }) {
                 </div>
                 <div className={"headerOptions"}>
                     <div>Olá, {name}</div>
+                    <div style={{cursor:'pointer'}} onClick={handleLogout}>Logout</div>
                 </div>
             </div>
             <div className={"headerBreak"}><span></span></div>


### PR DESCRIPTION
## Summary
- add a Logout item to the header that clears auth info
- redirect to /login when the token is missing or expired

## Testing
- `npm install` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_6859a357eae4833194af6a1479e3841c