### PR TITLE
Add pagination and clean up front-end

### DIFF
--- a/front/src/api/_api.js
+++ b/front/src/api/_api.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 let env  = process.env
-console.log(env)
 const api = axios.create({ 'baseURL': env.REACT_APP_BASE_URL })
 
 api.interceptors.request.use(

--- a/front/src/components/Pagination/Pagination.jsx
+++ b/front/src/components/Pagination/Pagination.jsx
@@ -1,0 +1,29 @@
+import '../styles/pagination.scss';
+
+export default function Pagination({ currentPage, totalPages, onPageChange }) {
+  if (totalPages <= 1) return null;
+
+  const pages = [];
+  for (let i = 1; i <= totalPages; i++) {
+    pages.push(
+      <button
+        key={i}
+        className={i === currentPage ? 'active' : ''}
+        onClick={() => onPageChange(i)}>
+        {i}
+      </button>
+    );
+  }
+
+  return (
+    <div className="pagination">
+      <button disabled={currentPage === 1} onClick={() => onPageChange(currentPage - 1)}>
+        Anterior
+      </button>
+      {pages}
+      <button disabled={currentPage === totalPages} onClick={() => onPageChange(currentPage + 1)}>
+        Próximo
+      </button>
+    </div>
+  );
+}

--- a/front/src/components/Table/table.jsx
+++ b/front/src/components/Table/table.jsx
@@ -3,16 +3,20 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Empty from "../Empty/empty";
 import './table.scss';
 
-export default function Table({ 
+export default function Table({
     data = [],
     emptyMessage = 'There are no items in the table',
     useOptions = false,
     deleteCallback = undefined,
-    detailsCallback = undefined
+    detailsCallback = undefined,
+    page = 1,
+    itemsPerPage = 10
 }) {
     if (data.length > 0) {
         var columns = Object.keys(data[0]);
-        var rows = data.map(row => columns.map(column => row[column]));
+        const start = (page - 1) * itemsPerPage;
+        const pageData = data.slice(start, start + itemsPerPage);
+        var rows = pageData.map(row => columns.map(column => row[column]));
         
         return (
             <div className="table">

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -11,4 +11,4 @@ root.render(
   </React.StrictMode>
 );
 
-reportWebVitals(console.log);
+reportWebVitals();

--- a/front/src/pages/course/courseList.jsx
+++ b/front/src/pages/course/courseList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import '../../styles/courseList.scss'
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getCourses } from "../../api/course_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode"
@@ -13,6 +14,8 @@ export default function CourseList(){
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [isLoading, setIsLoading] = useState(true)
     const [courses, setCourses] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     useEffect(()=>{
         const roles = ['Administrator','Professor','Student']
@@ -57,16 +60,14 @@ export default function CourseList(){
                     <div className="title">Cursos</div>
                 </div>
                 {role === 'Administrator' && <div className="right-bar">
-                    <div className="search">
-                        <input type="search" name="search" id="search" />
-                    </div>
                     <div className="create-button">
                         <button onClick={()=>navigate('/courses/add')}>Novo Curso</button>
                     </div>
                 </div>}
             </div>
             <BackButton />
-            <Table data={courses} useOptions={role!=='Student'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+            <Table data={courses} page={currentPage} itemsPerPage={itemsPerPage} useOptions={role!=='Student'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(courses.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     )
 }

--- a/front/src/pages/extension/extensionList.jsx
+++ b/front/src/pages/extension/extensionList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import '../../styles/extensionList.scss';
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getExtensions } from "../../api/extension_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode";
@@ -16,6 +17,8 @@ export default function ExtensionList() {
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState(false)
     const [extensions, setextensions] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     useEffect(() => {
         const roles = ['Administrator', 'Student']
@@ -62,15 +65,11 @@ export default function ExtensionList() {
                         </div>
                         <div className="title">Extensões</div>
                     </div>
-                    <div className="right-bar">
-                        <div className="search">
-                            <input type="search" name="search" id="search" />
-                            <i className="fas fa-" />
-                        </div>
-                    </div>
+                    <div className="right-bar"></div>
                 </div>
                 <BackButton />
-                <Table data={extensions} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+                <Table data={extensions} page={currentPage} itemsPerPage={itemsPerPage} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+                <Pagination currentPage={currentPage} totalPages={Math.ceil(extensions.length/itemsPerPage)} onPageChange={setCurrentPage} />
                 {error && < ErrorPage/>}
     </PageContainer>)
 }

--- a/front/src/pages/professor/professorList.jsx
+++ b/front/src/pages/professor/professorList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import '../../styles/professorList.scss';
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getProfessors } from "../../api/professor_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode";
@@ -14,6 +15,8 @@ export default function ProfessorList() {
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [isLoading, setIsLoading] = useState(true)
     const [professors, setProfessors] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     const detailsCallback = (id)=>
     {
@@ -39,7 +42,6 @@ export default function ProfessorList() {
             .then(result => {
                 let mapped = []
                 if (result !== null && result !== undefined) {
-                    console.log(result)
                     mapped = result.map((professor) => {
                         return {
                             Id: professor.id,
@@ -64,17 +66,14 @@ export default function ProfessorList() {
                 <div className="title">Professores</div>
             </div>
             <div className="right-bar">
-                <div className="search">
-                    <input type="search" name="search" id="search" />
-                    <i className="fas fa-"/>
-                </div>
                 <div className="create-button">
                     <button onClick={()=> navigate('/professors/add')}>Novo Professor</button>
                 </div>
             </div>
         </div>
         <BackButton />
-        {!isLoading && <Table data={professors} useOptions={true} detailsCallback={detailsCallback} />}
+        {!isLoading && <Table data={professors} page={currentPage} itemsPerPage={itemsPerPage} useOptions={true} detailsCallback={detailsCallback} />}
+        <Pagination currentPage={currentPage} totalPages={Math.ceil(professors.length/itemsPerPage)} onPageChange={setCurrentPage} />
     </PageContainer>
 )
 }

--- a/front/src/pages/projects/projectList.jsx
+++ b/front/src/pages/projects/projectList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import '../../styles/projectList.scss';
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getProjects } from "../../api/project_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode";
@@ -15,6 +16,8 @@ export default function ProjectList() {
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [isLoading, setIsLoading] = useState(true)
     const [projects, setProjects] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     const detailsCallback = (id)=>
     {
@@ -66,16 +69,13 @@ export default function ProjectList() {
                     <div className="title">Projetos</div>
                 </div>
                 <div className="right-bar">
-                    <div className="search">
-                        <input type="search" name="search" id="search" />
-                        <i className="fas fa-" />
-                    </div>
                     {role === 'Administrator' && <div className="create-button">
                         <button onClick={() => navigate('/projects/add')}>Novo Projeto</button>
                     </div>}
                 </div>
             </div>
-            <BackButton /><Table data={projects} useOptions={role === 'Administrator'} detailsCallback={detailsCallback} />
+            <BackButton /><Table data={projects} page={currentPage} itemsPerPage={itemsPerPage} useOptions={role === 'Administrator'} detailsCallback={detailsCallback} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(projects.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     )
 }

--- a/front/src/pages/research/researchList.jsx
+++ b/front/src/pages/research/researchList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import "../../styles/researchList.scss";
 import Table from "../../components/Table/table";
+import Pagination from "../../components/Pagination/Pagination";
 import { getResearch } from "../../api/research_service";
 import { useNavigate } from "react-router";
 import jwt_decode from "jwt-decode";
@@ -16,6 +17,8 @@ export default function ResearchList() {
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [researches, setResearches] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   useEffect(() => {
     const roles = ["Administrator", "Professor"];
@@ -35,7 +38,6 @@ export default function ResearchList() {
     getResearch()
       .then((result) => {
         let mapped = [];
-        console.log(result);
         if (result !== null && result !== undefined) {
           mapped = result.map((research) => {
             return {
@@ -51,7 +53,6 @@ export default function ResearchList() {
         setIsLoading(false);
       })
       .catch((error) => {
-        console.log(error);
         setError(true);
         setErrorMessage(error?.message || 'Erro ao carregar dissertações');
         setIsLoading(false);
@@ -75,7 +76,8 @@ export default function ResearchList() {
             </div>
           </div>
           <BackButton />
-          <Table data={researches} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+          <Table data={researches} page={currentPage} itemsPerPage={itemsPerPage} useOptions={role === 'Administrator'} detailsCallback={(id)=>navigate(`${id}/edit`)} />
+          <Pagination currentPage={currentPage} totalPages={Math.ceil(researches.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </>
       ) : (
         <InlineError message={errorMessage} />

--- a/front/src/pages/researchLine/researchLineList.jsx
+++ b/front/src/pages/researchLine/researchLineList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import "../../styles/researchLineList.scss";
 import Table from "../../components/Table/table";
+import Pagination from "../../components/Pagination/Pagination";
 import { getResearchLines, deleteResearchLine } from "../../api/research_line";
 import { useNavigate } from "react-router";
 import jwt_decode from "jwt-decode";
@@ -15,6 +16,8 @@ export default function ResearchLineList() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
   const [lines, setLines] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   useEffect(() => {
     const roles = ["Administrator", "Student", "Professor"];
@@ -45,7 +48,6 @@ export default function ResearchLineList() {
         setIsLoading(false);
       })
       .catch((error) => {
-        console.log(error);
         setError(true);
         setIsLoading(false);
       });
@@ -81,10 +83,13 @@ export default function ResearchLineList() {
           <BackButton />
           <Table
             data={lines}
+            page={currentPage}
+            itemsPerPage={itemsPerPage}
             useOptions={role === 'Administrator'}
             deleteCallback={handleDelete}
             detailsCallback={(id) => navigate(`${id}/edit`)}
           />
+          <Pagination currentPage={currentPage} totalPages={Math.ceil(lines.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </>
       ) : (
         <ErrorPage />

--- a/front/src/pages/researcher/researcherList.jsx
+++ b/front/src/pages/researcher/researcherList.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import '../../styles/researcherList.scss';
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getResearchers } from "../../api/researcher_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode";
@@ -13,6 +14,8 @@ export default function ResearcherList() {
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [isLoading, setIsLoading] = useState(true)
     const [researchers, setResearchers] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     const detailsCallback = (id) => {
         navigate(id)
@@ -61,17 +64,14 @@ export default function ResearcherList() {
                     <div className="title">Pesquisadores</div>
                 </div>
                 <div className="right-bar">
-                    <div className="search">
-                        <input type="search" name="search" id="search" />
-                        <i className="fas fa-" />
-                    </div>
                     <div className="create-button">
                         <button onClick={() => navigate('/researches/add')}>Novo Pesquisador</button>
                     </div>
                 </div>
             </div>
             <BackButton />
-            <Table data={researchers} useOptions={true} detailsCallback={detailsCallback} />
+            <Table data={researchers} page={currentPage} itemsPerPage={itemsPerPage} useOptions={true} detailsCallback={detailsCallback} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(researchers.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     )
 }

--- a/front/src/pages/student/StudentList.jsx
+++ b/front/src/pages/student/StudentList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import '../../styles/studentList.scss'
 import Table from "../../components/Table/table"
+import Pagination from "../../components/Pagination/Pagination"
 import { getStudents } from "../../api/student_service"
 import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode";
@@ -18,6 +19,8 @@ export default function StudentList() {
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [isLoading, setIsLoading] = useState(true)
     const [students, setStudents] = useState([])
+    const [currentPage, setCurrentPage] = useState(1)
+    const itemsPerPage = 10
 
     useEffect(() => {
         const roles = ['Administrator', 'Professor']
@@ -64,17 +67,14 @@ export default function StudentList() {
                     <div className="title">Estudantes</div>
                 </div>
                 {role === 'Administrator' && <div className="right-bar">
-                    <div className="search">
-                        <input type="search" name="search" id="search" />
-                        <i className="fas fa-" />
-                    </div>
                     <div className="create-button">
                         <button onClick={() => navigate('/students/add')}>Novo Estudante</button>
                     </div>
                 </div>}
             </div>
             <BackButton ></BackButton>
-            <Table data={students} useOptions={true} detailsCallback={(id) => navigate(`${id}`)} />
+            <Table data={students} page={currentPage} itemsPerPage={itemsPerPage} useOptions={true} detailsCallback={(id) => navigate(`${id}`)} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(students.length / itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     )
 }

--- a/front/src/pages/user/userList.jsx
+++ b/front/src/pages/user/userList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import '../../styles/userList.scss';
 import Table from "../../components/Table/table";
+import Pagination from "../../components/Pagination/Pagination";
 import { getUsers, deleteUser } from "../../api/user_service";
 import { useNavigate } from "react-router";
 import jwt_decode from "jwt-decode";
@@ -15,6 +16,8 @@ export default function UserList() {
     const [users, setUsers] = useState([]);
     const [tableData, setTableData] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 10;
 
     useEffect(() => {
         const token = localStorage.getItem('token');
@@ -80,16 +83,14 @@ export default function UserList() {
                     <div className="title">Usuários</div>
                 </div>
                 <div className="right-bar">
-                    <div className="search">
-                        <input type="search" name="search" id="search" />
-                    </div>
                     <div className="create-button">
                         <button onClick={() => navigate('/user/add')}>Novo Usuário</button>
                     </div>
                 </div>
             </div>
             <BackButton />
-            <Table data={tableData} useOptions={true} detailsCallback={handleDetails} deleteCallback={handleDelete} />
+            <Table data={tableData} page={currentPage} itemsPerPage={itemsPerPage} useOptions={true} detailsCallback={handleDetails} deleteCallback={handleDelete} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(tableData.length/itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     );
 }

--- a/front/src/styles/pagination.scss
+++ b/front/src/styles/pagination.scss
@@ -1,0 +1,24 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin: 1rem 0;
+
+  button {
+    border: none;
+    background: none;
+    padding: 0.5rem 0.75rem;
+    margin: 0 0.25rem;
+    color: #004AAD;
+    cursor: pointer;
+  }
+
+  button.active {
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Pagination component
- paginate Table component rows
- remove unused search boxes and logging
- clean up web vitals call
- apply pagination across list pages

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b37a04148331aeaf6184fa08de87