### PR TITLE
Improve frontend error handling

### DIFF
--- a/front/src/api/_api.js
+++ b/front/src/api/_api.js
@@ -1,44 +1,43 @@
 import axios from 'axios';
 
-let env  = process.env
-const api = axios.create({ 'baseURL': env.REACT_APP_BASE_URL })
+const env = process.env;
+const api = axios.create({ baseURL: env.REACT_APP_BASE_URL });
 
 api.interceptors.request.use(
-    (config) => {
-      config.headers.set('Access-Control-Allow-Origin','*')
-      const token = localStorage.getItem('token');
-      if (token) {
-        config.headers['Authorization'] = `Bearer ${token}`;
-      }
-      return config;
-    },
-    (error) => {
-      return Promise.reject(error);
+  (config) => {
+    config.headers.set('Access-Control-Allow-Origin', '*');
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
     }
-  );
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
-  api.interceptors.response.use(
-    (response)=> {
-      if(response.status === 401)
-      {
-        localStorage.removeItem('token')
-        localStorage.removeItem('role')
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response) {
+      if (error.response.status === 401) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
       }
-      return response
-    },
-    (error)=>{
-      if(error.response){
-        return Promise.reject(error.response.data)
+      const data = error.response.data;
+      if (typeof data === 'string') {
+        return Promise.reject({ message: data });
       }
-      return Promise.reject({ message: error.message })
+      return Promise.reject({ message: data?.message || 'Request failed' });
     }
-  )
+    return Promise.reject({ message: error.message });
+  }
+);
 
-  api.postWithoutToken = (url, data, config) => {
-    return axios.post((env.REACT_APP_BASE_URL + "/" + url), data, config);
-  };
+api.postWithoutToken = (url, data, config) => {
+  return axios.post(env.REACT_APP_BASE_URL + '/' + url, data, config);
+};
 
-  export default api
+export default api;
 
 
 

--- a/front/src/pages/changePassword.jsx
+++ b/front/src/pages/changePassword.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import '../styles/login.scss';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ResetPassword as resetPassword } from '../api/user_service';
+import InlineError from '../components/error/InlineError';
 
 export default function ResetPassword() {
   const navigate = useNavigate();
@@ -41,7 +42,7 @@ export default function ResetPassword() {
         }
       })
       .catch((error) => {
-        setError('Failed to reset password');
+        setError(error?.message || 'Failed to reset password');
       });
   };
 
@@ -78,7 +79,7 @@ export default function ResetPassword() {
               required
             />
             <input type="submit" id="submit" value={'Resetar Senha'} onClick={handleSubmit} />
-            {error && <p>{error}</p>}
+            <InlineError message={error} />
           </div>
         </div>
       </main>

--- a/front/src/pages/login.jsx
+++ b/front/src/pages/login.jsx
@@ -65,8 +65,8 @@ export default function Login() {
           setErrorModal('Email Invalido');
         }
       })
-      .catch(() => {
-        setErrorModal('Email Invalido');
+      .catch((err) => {
+        setErrorModal(err?.message || 'Email Invalido');
       });
   };
 
@@ -133,7 +133,7 @@ export default function Login() {
                     onChange={(e) => setModalEmail(e.target.value)}
                   />
                   <input type="submit" id="resetSubmit" value={'Resetar Senha'} onClick={handleResetPassword} />
-                  {errorModal && <p>{errorModal}</p>}
+                  <InlineError message={errorModal} />
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- improve API interceptor to always return useful error messages
- show backend error messages on login, password reset pages
- switch to consistent InlineError component for better feedback

## Testing
- `npm install --prefix front`
- `CI=true npm test` *(fails: Jest cannot parse ESM imports)*

------
https://chatgpt.com/codex/tasks/task_e_6859be5ebac4833195b3680278ba79cb