### PR TITLE
Improve backend and frontend error messages

### DIFF
--- a/backend/Controllers/CourseController.cs
+++ b/backend/Controllers/CourseController.cs
@@ -31,7 +31,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -52,7 +52,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -84,7 +84,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -102,7 +102,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/ExtensionController.cs
+++ b/backend/Controllers/ExtensionController.cs
@@ -34,7 +34,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -54,7 +54,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -85,7 +85,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -105,7 +105,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/ExternalResearcherController.cs
+++ b/backend/Controllers/ExternalResearcherController.cs
@@ -33,7 +33,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -54,7 +54,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -84,7 +84,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -104,7 +104,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/OrientationController.cs
+++ b/backend/Controllers/OrientationController.cs
@@ -34,7 +34,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -54,7 +54,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -85,7 +85,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -105,7 +105,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/ProfessorController.cs
+++ b/backend/Controllers/ProfessorController.cs
@@ -35,7 +35,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -56,7 +56,7 @@ namespace saga.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "An error occurred: {ErrorMessage}. Stack trace: {StackTrace}", ex.Message, ex.StackTrace);
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -87,7 +87,7 @@ namespace saga.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "An error occurred: {ErrorMessage}. Stack trace: {StackTrace}", ex.Message, ex.StackTrace);
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -107,7 +107,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/ProjectController.cs
+++ b/backend/Controllers/ProjectController.cs
@@ -33,7 +33,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -53,7 +53,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -87,7 +87,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -107,7 +107,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/ResearchLineController.cs
+++ b/backend/Controllers/ResearchLineController.cs
@@ -33,7 +33,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -53,7 +53,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -87,7 +87,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -107,7 +107,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/StudentController.cs
+++ b/backend/Controllers/StudentController.cs
@@ -28,7 +28,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -43,7 +43,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -58,7 +58,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -73,7 +73,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -88,7 +88,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -104,7 +104,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -121,7 +121,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -137,7 +137,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -28,7 +28,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -42,7 +42,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -57,7 +57,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -73,7 +73,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -88,7 +88,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -103,7 +103,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -118,7 +118,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
 
@@ -133,7 +133,7 @@ namespace saga.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequest(new { message = ex.Message });
             }
         }
     }

--- a/backend/Infrastructure/Providers/ErrorHandlingMiddleware.cs
+++ b/backend/Infrastructure/Providers/ErrorHandlingMiddleware.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+
+namespace saga.Infrastructure.Providers
+{
+    /// <summary>
+    /// Middleware for converting unhandled exceptions into JSON error responses.
+    /// </summary>
+    public class ErrorHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+        public ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandlingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (ArgumentException ex)
+            {
+                await WriteResponseAsync(context, StatusCodes.Status400BadRequest, ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                await WriteResponseAsync(context, StatusCodes.Status401Unauthorized, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception");
+                await WriteResponseAsync(context, StatusCodes.Status500InternalServerError, "Internal server error");
+            }
+        }
+
+        private static async Task WriteResponseAsync(HttpContext context, int statusCode, string message)
+        {
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            var json = JsonSerializer.Serialize(new { message });
+            await context.Response.WriteAsync(json);
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -108,6 +108,7 @@ app.UseSwaggerUI(c =>
 
 app.UseCors("CorsPolicy");
 
+app.UseMiddleware<ErrorHandlingMiddleware>();
 app.UseHttpsRedirection();
 app.UseRouting();
 app.UseAuthentication();

--- a/front/src/api/_api.js
+++ b/front/src/api/_api.js
@@ -1,44 +1,43 @@
 import axios from 'axios';
 
-let env  = process.env
-const api = axios.create({ 'baseURL': env.REACT_APP_BASE_URL })
+const env = process.env;
+const api = axios.create({ baseURL: env.REACT_APP_BASE_URL });
 
 api.interceptors.request.use(
-    (config) => {
-      config.headers.set('Access-Control-Allow-Origin','*')
-      const token = localStorage.getItem('token');
-      if (token) {
-        config.headers['Authorization'] = `Bearer ${token}`;
-      }
-      return config;
-    },
-    (error) => {
-      return Promise.reject(error);
+  (config) => {
+    config.headers.set('Access-Control-Allow-Origin', '*');
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
     }
-  );
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
-  api.interceptors.response.use(
-    (response)=> {
-      if(response.status === 401)
-      {
-        localStorage.removeItem('token')
-        localStorage.removeItem('role')
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response) {
+      if (error.response.status === 401) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
       }
-      return response
-    },
-    (error)=>{
-      if(error.response){
-        return Promise.reject(error.response.data)
+      const data = error.response.data;
+      if (typeof data === 'string') {
+        return Promise.reject({ message: data });
       }
-      return Promise.reject({ message: error.message })
+      return Promise.reject({ message: data?.message || 'Request failed' });
     }
-  )
+    return Promise.reject({ message: error.message });
+  }
+);
 
-  api.postWithoutToken = (url, data, config) => {
-    return axios.post((env.REACT_APP_BASE_URL + "/" + url), data, config);
-  };
+api.postWithoutToken = (url, data, config) => {
+  return axios.post(env.REACT_APP_BASE_URL + '/' + url, data, config);
+};
 
-  export default api
+export default api;
 
 
 

--- a/front/src/pages/changePassword.jsx
+++ b/front/src/pages/changePassword.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import '../styles/login.scss';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ResetPassword as resetPassword } from '../api/user_service';
+import InlineError from '../components/error/InlineError';
 
 export default function ResetPassword() {
   const navigate = useNavigate();
@@ -41,7 +42,7 @@ export default function ResetPassword() {
         }
       })
       .catch((error) => {
-        setError('Failed to reset password');
+        setError(error?.message || 'Failed to reset password');
       });
   };
 
@@ -78,7 +79,7 @@ export default function ResetPassword() {
               required
             />
             <input type="submit" id="submit" value={'Resetar Senha'} onClick={handleSubmit} />
-            {error && <p>{error}</p>}
+            <InlineError message={error} />
           </div>
         </div>
       </main>

--- a/front/src/pages/login.jsx
+++ b/front/src/pages/login.jsx
@@ -65,8 +65,8 @@ export default function Login() {
           setErrorModal('Email Invalido');
         }
       })
-      .catch(() => {
-        setErrorModal('Email Invalido');
+      .catch((err) => {
+        setErrorModal(err?.message || 'Email Invalido');
       });
   };
 
@@ -133,7 +133,7 @@ export default function Login() {
                     onChange={(e) => setModalEmail(e.target.value)}
                   />
                   <input type="submit" id="resetSubmit" value={'Resetar Senha'} onClick={handleResetPassword} />
-                  {errorModal && <p>{errorModal}</p>}
+                  <InlineError message={errorModal} />
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- format controller errors as objects
- add global ErrorHandlingMiddleware
- show backend error messages in login and password reset pages

## Testing
- `npm install --prefix front`
- `CI=true npm test` *(fails: Jest cannot parse ESM imports)*

------
https://chatgpt.com/codex/tasks/task_e_6859be5ebac4833195b3680278ba79cb