### PR TITLE
Fix loading states when API calls fail

### DIFF
--- a/front/src/pages/projects/projectList.jsx
+++ b/front/src/pages/projects/projectList.jsx
@@ -53,10 +53,10 @@ export default function ProjectList() {
                     })
                 }
                 setProjects(mapped)
-                setIsLoading(false)
-
             })
-    }, [setProjects, setIsLoading])
+            .catch(() => { })
+            .finally(() => setIsLoading(false))
+    }, [])
 
 
     return (

--- a/front/src/pages/student/StudentList.jsx
+++ b/front/src/pages/student/StudentList.jsx
@@ -52,10 +52,10 @@ export default function StudentList() {
                     }))
                 }
                 setStudents(mapped)
-                setIsLoading(false)
-
             })
-    }, [setStudents, setIsLoading])
+            .catch(() => { })
+            .finally(() => setIsLoading(false))
+    }, [])
 
     return (
         <PageContainer name={name} isLoading={isLoading}>

--- a/front/src/pages/student/profile.jsx
+++ b/front/src/pages/student/profile.jsx
@@ -38,9 +38,9 @@ export default function StudentProfile() {
         getStudentById(id)
             .then(student => {
                 setStudent(student);
-                setIsLoading(false);
             })
-            .catch(() => setError(true));
+            .catch(() => setError(true))
+            .finally(() => setIsLoading(false));
         getResearch()
             .then(list => {
                 const orient = list?.find(o => o.student?.id === id);


### PR DESCRIPTION
## Summary
- ensure student and project pages stop loading if requests fail
- stop spinner when student profile fetch fails

## Testing
- `npm --prefix front test` *(fails: Jest cannot parse axios)*

------
https://chatgpt.com/codex/tasks/task_e_6859f7e8c08483319ae568caadf1898f