### PR TITLE
Atualiza sidebar e tela inicial

### DIFF
--- a/front/src/components/Sidebar.jsx
+++ b/front/src/components/Sidebar.jsx
@@ -20,28 +20,76 @@ export default function Sidebar({ open, onNavigate }) {
       </div>
       <NavLink to="/" onClick={onNavigate}>Início</NavLink>
       {(role === 'Professor' || role === 'Administrator') && (
-        <NavLink to="/students" onClick={onNavigate}>Estudantes</NavLink>
+        <NavLink to="/students" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/student.png'} alt="Estudantes" />
+          Estudantes
+        </NavLink>
       )}
       {role === 'Student' && studentId && (
-        <NavLink to={`/students/${studentId}`} onClick={onNavigate}>Meu Perfil</NavLink>
+        <NavLink to={`/students/${studentId}`} onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/student.png'} alt="Perfil" />
+          Meu Perfil
+        </NavLink>
+      )}
+      {role === 'Student' && (
+        <NavLink to="/extensions" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/calender.png'} alt="Extensões" />
+          Pedidos de Extensão
+        </NavLink>
       )}
       {role === 'Administrator' && (
-        <NavLink to="/professors" onClick={onNavigate}>Professores</NavLink>
+        <NavLink to="/professors" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/professor.png'} alt="Professores" />
+          Professores
+        </NavLink>
       )}
       {role === 'Administrator' && (
-        <NavLink to="/researchers" onClick={onNavigate}>Pesquisadores</NavLink>
+        <NavLink to="/researchers" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/researcher.png'} alt="Pesquisadores" />
+          Pesquisadores
+        </NavLink>
       )}
       {(role === 'Administrator' || role === 'Professor') && (
-        <NavLink to="/researches" onClick={onNavigate}>Dissertações</NavLink>
+        <NavLink to="/researches" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/research.png'} alt="Dissertações" />
+          Dissertações
+        </NavLink>
       )}
       {(role === 'Administrator' || role === 'Professor') && (
-        <NavLink to="/projects" onClick={onNavigate}>Projetos</NavLink>
+        <NavLink to="/projects" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/lamp.png'} alt="Projetos" />
+          Projetos
+        </NavLink>
+      )}
+      {(role === 'Administrator' || role === 'Professor' || role === 'Student') && (
+        <NavLink to="/courses" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/lamp.png'} alt="Cursos" />
+          Cursos
+        </NavLink>
+      )}
+      {(role === 'Administrator' || role === 'Professor' || role === 'Student') && (
+        <NavLink to="/researchLines" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/research.png'} alt="Linhas" />
+          Linhas de Pesquisa
+        </NavLink>
       )}
       {role === 'Administrator' && (
-        <NavLink to="/extensions" onClick={onNavigate}>Extensões</NavLink>
+        <NavLink to="/users" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/professor.png'} alt="Usuários" />
+          Usuários
+        </NavLink>
       )}
       {role === 'Administrator' && (
-        <NavLink to="/entities/csv" onClick={onNavigate}>Carregar CSV</NavLink>
+        <NavLink to="/extensions" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/calender.png'} alt="Extensões" />
+          Extensões
+        </NavLink>
+      )}
+      {role === 'Administrator' && (
+        <NavLink to="/entities/csv" onClick={onNavigate}>
+          <img src={process.env.PUBLIC_URL + '/csv3.png'} alt="Carregar CSV" />
+          Carregar CSV
+        </NavLink>
       )}
     </nav>
   );

--- a/front/src/pages/home.jsx
+++ b/front/src/pages/home.jsx
@@ -6,104 +6,21 @@ import { useNavigate } from 'react-router-dom'
 import PageContainer from '../components/PageContainer';
 export default function Home() {
     const navigate = useNavigate()
-    var [role, setRole] = useState("")
     var [name, setName] = useState("")
-    const [studentId, setStudentId] = useState('')
     useEffect(() => {
-
         let token = localStorage.getItem('token')
         setName(localStorage.getItem('name'))
         try {
-            const decoded = jwt_decode(token)
-            setRole(decoded.role)
-            setStudentId(decoded.nameid)
+            jwt_decode(token)
         } catch (error) {
             navigate('/login')
         }
-    }, [navigate, setRole, setName]);
-
+    }, [navigate, setName]);
     return (
         <PageContainer isLoading={false} name={name}>
             <div className='home'>
-            <div>
-                <h2 id='pre'>Bem-vindo ao SAGA. Utilize os painéis abaixo para navegar:</h2>
-            </div>
-            <div className={"dashboard"}>
-                {(role === "Professor" || role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/students')}>
-                    <div id='student' className={"itemIcon"} >
-                        <img src={process.env.PUBLIC_URL +"/student.png"} alt="Estudantes" />
-                    </div>
-                    <label htmlFor='student' className={"iconLabel"}>Estudantes</label>
-                </div>}
-                {(role === "Student") && <div className={"boardItem"} onClick={() => navigate(`/students/${studentId}`)}>
-                    <div id='Profile' className={"itemIcon"} >
-                        <img src={process.env.PUBLIC_URL + "/student.png"} alt="Perfil" />
-                    </div>
-                    <label htmlFor='Profile' className={"iconLabel"}>Meu Perfil</label>
-                </div>}
-                {(role === "Student") && <div className={"boardItem"} onClick={() => navigate('/extensions')}>
-                    <div id='extensions' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/calender.png"} alt="Extens\u00f5es" />
-                    </div>
-                    <label htmlFor='extensions' className={"iconLabel"}>Pedidos de Extensão</label>
-                </div>}
-                {(role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/professors')}>
-                    <div id='professor' className={"itemIcon"} >
-                        <img src={process.env.PUBLIC_URL +"/professor.png"} alt="Professores" />
-                    </div>
-                    <label htmlFor='professor' className={"iconLabel"}>Professores</label>
-                </div>}
-                {(role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/researchers')}>
-                    <div id='researcher' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/researcher.png"} alt="Pesquisadores" />
-                    </div>
-                    <label htmlFor='researcher' className={"iconLabel"}>Pesquisadores</label>
-                </div>}
-                {(role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/users')}>
-                    <div id='users' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/professor.png"} alt="Usu\u00e1rios" />
-                    </div>
-                    <label htmlFor='users' className={"iconLabel"}>Usuários</label>
-                </div>}
-                {(role === "Administrator" || role === "Professor") && <div className={"boardItem"} onClick={() => navigate('/researches')}>
-                    <div id='research' className={"itemIcon"} >
-                        <img src={process.env.PUBLIC_URL +"/research.png"} alt="Disserta\u00e7\u00f5es" />
-                    </div>
-                    <label htmlFor='research' className={"iconLabel"}>Dissertações</label>
-                </div>}
-                {(role === "Administrator" || role === "Professor" || role === "Student") && <div className={"boardItem"} onClick={() => navigate('/courses')}>
-                    <div id='course' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/lamp.png"} alt="Cursos" />
-                    </div>
-                    <label htmlFor='course' className={"iconLabel"}>Cursos</label>
-                </div>}
-                {(role === "Administrator" || role === "Professor") && <div className={"boardItem"} onClick={() => navigate('/projects')}>
-                    <div id='project' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/lamp.png"} alt="Projetos" />
-                    </div>
-                    <label htmlFor='project' className={"iconLabel"}>Projetos</label>
-                </div>}
-                {/* {(role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/reports')}>
-                    <div id='report' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/report.png"} />
-                    </div>
-                    <label htmlFor='report' className={"iconLabel"}>Relatorios</label>
-                </div>} */}
-                {(role === "Administrator") && <div className={"boardItem"} onClick={() => navigate('/extensions')}>
-                    <div id='extension' className={"itemIcon"} >
-                        <img className={"filtered"} src={process.env.PUBLIC_URL +"/calender.png"} alt="Extens\u00f5es" />
-                    </div>
-                    <label htmlFor='extension' className={"iconLabel"}>Extensões</label>
-                </div>}
-                {
-                    (role === "Administrator") && <div className='boardItem' onClick={() => navigate('/entities/csv')}>
-                        <div id='entities'>
-                            <img className={"filtered"} src={process.env.PUBLIC_URL +"/csv3.png"} alt="Carregar CSV" />
-                        </div>
-                        <label htmlFor='entities' className={"iconLabel"}>Carregar CSV</label>
-                    </div>
-                }
-            </div>
+                <h2 id='pre'>Bem-vindo ao SAGA</h2>
+                <p>Utilize o menu lateral para navegar pelas funcionalidades do sistema.</p>
             </div>
         </PageContainer>
     );

--- a/front/src/styles/sidebar.scss
+++ b/front/src/styles/sidebar.scss
@@ -24,8 +24,17 @@
 
   a {
     color: inherit;
-    padding: 1rem;
+    padding: 0.75rem 1rem;
     text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    img {
+      width: 1.2rem;
+      height: 1.2rem;
+      filter: $filter;
+    }
   }
 
   a.active {


### PR DESCRIPTION
## Summary
- add missing menu items with icons to the Sidebar
- simplify Home page to a short presentation
- style sidebar links to support icons

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9238e308331a17f7c3578f27b32