### PR TITLE
Improve form error handling

### DIFF
--- a/front/src/pages/CsvImport.jsx
+++ b/front/src/pages/CsvImport.jsx
@@ -8,14 +8,14 @@ import Select from '../components/select';
 import jwt_decode from 'jwt-decode';
 import { useNavigate } from 'react-router';
 import { postStudentCsv, postStudentCourseCsv } from '../api/student_service';
-import ErrorPage from '../components/error/Error';
+import InlineError from '../components/error/InlineError';
 
 const CsvImport = () => {
     const [fileData, setFileData] = useState(null);
     const [file, setFile] = useState(null);
     const [name,] = useState(localStorage.getItem('name'))
     const [isLoading, setIsLoading] = useState(false)
-    const [error, setError] = useState(false)
+    const [error, setError] = useState('')
     const [entity, setEntity] = useState('Estudantes')
     const [message, setMessage] = useState('')
 
@@ -48,8 +48,8 @@ const CsvImport = () => {
                 .then((response) => {
                     navigate('/')
                 })
-                .catch((error) => {
-                    setError(true);
+                .catch((err) => {
+                    setError(err?.message || 'Erro ao importar dados');
                 });
         }
         else if (entity === 'Materias cursados')
@@ -58,9 +58,9 @@ const CsvImport = () => {
                 .then((response) => {
                     navigate('/')
                 })
-                .catch((error) => {
-                    setError(true);
-                }); 
+                .catch((err) => {
+                    setError(err?.message || 'Erro ao importar dados');
+                });
         }
         setIsLoading(false)
     };
@@ -72,7 +72,6 @@ const CsvImport = () => {
     }
     return (
         <PageContainer name={name} isLoading={isLoading}>
-            { !error &&
             <div className='csv-loader'>
             <div className="form csv">
                 <div className='form-section'>
@@ -100,14 +99,14 @@ const CsvImport = () => {
                     <div className='form-section'>
                         <div className='formInput'>
                             <input type={'submit'} value="Anexar" onClick={(e) => handleFileUpload()} />
+                            <InlineError message={error} />
                         </div>
                     </div>
                 </div>
             </div>
             {fileData && <Table data={fileData} />}
             {message && <div className='success'>{message}</div>}
-            </div>}
-            {error && <ErrorPage/>}
+            </div>
         </PageContainer>)
 };
 

--- a/front/src/pages/course/createCourse.jsx
+++ b/front/src/pages/course/createCourse.jsx
@@ -4,12 +4,14 @@ import { useNavigate } from "react-router"
 import jwt_decode from "jwt-decode"
 import BackButton from "../../components/BackButton"
 import PageContainer from "../../components/PageContainer"
+import InlineError from "../../components/error/InlineError"
 import { postCourse } from "../../api/course_service"
 
 export default function CreateCourse(){
     const navigate = useNavigate()
     const [name] = useState(localStorage.getItem('name'))
     const [role, setRole] = useState(localStorage.getItem('role'))
+    const [error, setError] = useState('')
     const [course, setCourse] = useState({
         name:'',
         courseUnique:'',
@@ -36,6 +38,7 @@ export default function CreateCourse(){
         e.preventDefault()
         postCourse(course)
             .then(()=>navigate(-1))
+            .catch(err => setError(err?.message || 'Erro ao salvar curso'))
     }
 
     return(
@@ -78,6 +81,7 @@ export default function CreateCourse(){
                 <div className='form-section'>
                     <div className='formInput'>
                         <input type='submit' value='Submit' onClick={handleSave}/>
+                        <InlineError message={error} />
                     </div>
                 </div>
             </form>

--- a/front/src/pages/course/updateCourse.jsx
+++ b/front/src/pages/course/updateCourse.jsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router"
 import jwt_decode from "jwt-decode"
 import BackButton from "../../components/BackButton"
 import PageContainer from "../../components/PageContainer"
+import InlineError from "../../components/error/InlineError"
 import { getCourseById, putCourseById } from "../../api/course_service"
 
 export default function UpdateCourse(){
@@ -13,6 +14,7 @@ export default function UpdateCourse(){
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [course, setCourse] = useState(null)
     const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState('')
 
     useEffect(()=>{
         const token = localStorage.getItem('token')
@@ -37,6 +39,7 @@ export default function UpdateCourse(){
         e.preventDefault()
         putCourseById(id, course)
             .then(()=>navigate('/courses'))
+            .catch(err=>setError(err?.message || 'Erro ao atualizar curso'))
     }
 
     if(!course) return <PageContainer name={name} isLoading={isLoading}><BackButton/></PageContainer>
@@ -81,6 +84,7 @@ export default function UpdateCourse(){
                 <div className='form-section'>
                     <div className='formInput'>
                         <input type='submit' value='Update' onClick={handleSave}/>
+                        <InlineError message={error} />
                     </div>
                 </div>
             </form>

--- a/front/src/pages/extension/createExtension.jsx
+++ b/front/src/pages/extension/createExtension.jsx
@@ -7,13 +7,14 @@ import Select from "../../components/select";
 import BackButton from "../../components/BackButton";
 import { postExtensions } from "../../api/extension_service";
 import PageContainer from "../../components/PageContainer";
+import InlineError from "../../components/error/InlineError";
 
 
 export default function ExtensionForm() {
     const navigate  = useNavigate()
     const { id}  = useParams()
     const [name,] = useState(localStorage.getItem('name'))
-    const [error, setError] = useState(null);
+    const [error, setError] = useState('');
     const [role, setRole] = useState(localStorage.getItem('role'))
     const [extension, setExtension] = useState(
         {
@@ -50,7 +51,7 @@ export default function ExtensionForm() {
     const handlepost = async () => {
         postExtensions(extension)
         .then(result => navigate(-1))
-        .catch(errors=>setError(true));
+        .catch(err=>setError(err?.message || 'Erro ao criar prorrogação'));
     }
 
     const handleSave = (e)=>{
@@ -83,9 +84,10 @@ export default function ExtensionForm() {
                 <div className="form-section">
                     <div className="formInput">
                         <input type="submit" value={"Submit"} onClick={(e)=> handleSave(e)} />
-                    </div>                 
+                        <InlineError message={error} />
+                    </div>
                 </div>
-            </div>          
+            </div>
         </PageContainer>
-);
+    );
 }

--- a/front/src/pages/extension/updateExtension.jsx
+++ b/front/src/pages/extension/updateExtension.jsx
@@ -5,7 +5,7 @@ import jwt_decode from "jwt-decode";
 import Select from "../../components/select";
 import BackButton from "../../components/BackButton";
 import PageContainer from "../../components/PageContainer";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import { getExtensionById, putExtensionById } from "../../api/extension_service";
 
 export default function ExtensionUpdate(){
@@ -14,7 +14,7 @@ export default function ExtensionUpdate(){
     const [name] = useState(localStorage.getItem('name'));
     const [role, setRole] = useState(localStorage.getItem('role'));
     const [extension, setExtension] = useState();
-    const [error, setError] = useState(false);
+    const [error, setError] = useState('');
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(()=>{
@@ -30,7 +30,7 @@ export default function ExtensionUpdate(){
     useEffect(()=>{
         getExtensionById(id)
             .then(res => { setExtension(res); setIsLoading(false); })
-            .catch(()=>{ setError(true); setIsLoading(false); });
+            .catch(err => { setError(err?.message || 'Erro ao carregar prorrogação'); setIsLoading(false); });
     }, [id]);
 
     const setDays = (val)=> setExtension({...extension, numberOfDays: Number(val)});
@@ -40,13 +40,13 @@ export default function ExtensionUpdate(){
         e.preventDefault();
         putExtensionById(id, extension)
             .then(()=>navigate(-1))
-            .catch(()=>setError(true));
+            .catch(err=>setError(err?.message || 'Erro ao atualizar prorrogação'));
     };
 
     return (
         <PageContainer name={name} isLoading={isLoading}>
             <BackButton />
-            {!error && extension && (
+            {extension && (
                 <div className='extensionForm'>
                     <div className='form-section'>
                         <div className='formInput'>
@@ -65,11 +65,12 @@ export default function ExtensionUpdate(){
                     <div className='form-section'>
                         <div className='formInput'>
                             <input type='submit' value='Update' onClick={handleUpdate}/>
+                            <InlineError message={error} />
                         </div>
                     </div>
                 </div>
             )}
-            {error && <ErrorPage />}
+            {!extension && <InlineError message={error} />}
         </PageContainer>
     );
 }

--- a/front/src/pages/projects/createProject.jsx
+++ b/front/src/pages/projects/createProject.jsx
@@ -6,7 +6,7 @@ import { getProfessors } from "../../api/professor_service"
 import Select from "../../components/select";
 import BackButton from "../../components/BackButton";
 import MultiSelect from "../../components/Multiselect";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { postProjects, getProjectById, putProjectsById } from "../../api/project_service";
 import { getResearchLines } from "../../api/research_line";
@@ -16,7 +16,7 @@ export default function ProjectForm({ Update = false }) {
   const { id } = useParams();
   const navigate = useNavigate();
   const [name,] = useState(localStorage.getItem('name'));
-  const [error, setError] = useState(null);
+  const [error, setError] = useState('');
   const [isUpdate] = useState(Update);
   const [isLoading, setIsLoading] = useState(true);
   const [professors, setProfessors] = useState([]);
@@ -73,7 +73,7 @@ export default function ProjectForm({ Update = false }) {
           setIsLoading(false);
         })
         .catch(err => {
-          setError(true);
+          setError(err?.message || 'Erro ao carregar projeto');
           setIsLoading(false);
         });
     }
@@ -108,13 +108,13 @@ export default function ProjectForm({ Update = false }) {
   const handlePost = () => {
     postProjects(project)
       .then(() => navigate(-1))
-      .catch((error) => setError(error));
+      .catch((err) => setError(err?.message || 'Erro ao salvar projeto'));
   };
 
   const handleUpdate = () => {
     putProjectsById(id, project)
       .then(() => navigate("/projects"))
-      .catch((error) => setError(error));
+      .catch((err) => setError(err?.message || 'Erro ao atualizar projeto'));
   };
 
   const handleSave = (e) => {
@@ -132,8 +132,7 @@ export default function ProjectForm({ Update = false }) {
   return (
     <PageContainer isLoading={isLoading} name={name}>
       <BackButton />
-      {!error && (
-        <form className="form">
+      <form className="form">
           <div className="form-section">
             <div className="formInput">
               <label htmlFor="name">Nome</label>
@@ -176,11 +175,10 @@ export default function ProjectForm({ Update = false }) {
           <div className="form-section">
             <div className="formInput">
               <input type="submit" value={isUpdate ? "Update" : "Submit"} onClick={(e) => handleSave(e)} />
+              <InlineError message={error} />
             </div>
           </div>
-        </form>
-      )}
-      {error && <ErrorPage />}
+      </form>
     </PageContainer>
   );
 }

--- a/front/src/pages/researchLine/createResearchLine.jsx
+++ b/front/src/pages/researchLine/createResearchLine.jsx
@@ -3,7 +3,7 @@ import "../../styles/form.scss";
 import { useNavigate } from "react-router";
 import jwt_decode from "jwt-decode";
 import BackButton from "../../components/BackButton";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { postResearchLine } from "../../api/research_line";
 
@@ -12,7 +12,7 @@ export default function CreateResearchLine() {
   const [name] = useState(localStorage.getItem("name"));
   const [role, setRole] = useState(localStorage.getItem("role"));
   const [line, setLine] = useState({ name: "" });
-  const [error, setError] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     const roles = ["Administrator"];
@@ -32,36 +32,33 @@ export default function CreateResearchLine() {
     e.preventDefault();
     postResearchLine(line)
       .then(() => navigate(-1))
-      .catch(() => setError(true));
+      .catch((err) => setError(err?.message || 'Erro ao salvar linha de pesquisa'));
   };
 
   return (
     <PageContainer name={name} isLoading={false}>
       <BackButton />
-      {!error ? (
-        <form className="form">
-          <div className="form-section">
-            <div className="formInput">
-              <label htmlFor="name">Nome</label>
-              <input
-                required
-                type="text"
-                name="name"
-                value={line.name}
-                onChange={(e) => setLine({ name: e.target.value })}
-                id="name"
-              />
-            </div>
+      <form className="form">
+        <div className="form-section">
+          <div className="formInput">
+            <label htmlFor="name">Nome</label>
+            <input
+              required
+              type="text"
+              name="name"
+              value={line.name}
+              onChange={(e) => setLine({ name: e.target.value })}
+              id="name"
+            />
           </div>
-          <div className="form-section">
-            <div className="formInput">
-              <input type="submit" value={"Submit"} onClick={handleSave} />
-            </div>
+        </div>
+        <div className="form-section">
+          <div className="formInput">
+            <input type="submit" value={"Submit"} onClick={handleSave} />
+            <InlineError message={error} />
           </div>
-        </form>
-      ) : (
-        <ErrorPage />
-      )}
+        </div>
+      </form>
     </PageContainer>
   );
 }

--- a/front/src/pages/researchLine/updateResearchLine.jsx
+++ b/front/src/pages/researchLine/updateResearchLine.jsx
@@ -3,7 +3,7 @@ import "../../styles/form.scss";
 import { useNavigate, useParams } from "react-router";
 import jwt_decode from "jwt-decode";
 import BackButton from "../../components/BackButton";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { getResearchLines } from "../../api/research_line";
 import { putResearchLine } from "../../api/research_line";
@@ -14,7 +14,7 @@ export default function UpdateResearchLine() {
   const [name] = useState(localStorage.getItem("name"));
   const [role, setRole] = useState(localStorage.getItem("role"));
   const [line, setLine] = useState({ name: "" });
-  const [error, setError] = useState(false);
+  const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -40,8 +40,8 @@ export default function UpdateResearchLine() {
         }
         setIsLoading(false);
       })
-      .catch(() => {
-        setError(true);
+      .catch((err) => {
+        setError(err?.message || 'Erro ao carregar linha de pesquisa');
         setIsLoading(false);
       });
   }, [id]);
@@ -50,17 +50,16 @@ export default function UpdateResearchLine() {
     e.preventDefault();
     putResearchLine(id, line)
       .then(() => navigate(-1))
-      .catch(() => setError(true));
+      .catch((err) => setError(err?.message || 'Erro ao atualizar linha de pesquisa'));
   };
 
   return (
     <PageContainer name={name} isLoading={isLoading}>
       <BackButton />
-      {!error ? (
-        <form className="form">
-          <div className="form-section">
-            <div className="formInput">
-              <label htmlFor="name">Nome</label>
+      <form className="form">
+        <div className="form-section">
+          <div className="formInput">
+            <label htmlFor="name">Nome</label>
               <input
                 required
                 type="text"
@@ -72,14 +71,13 @@ export default function UpdateResearchLine() {
             </div>
           </div>
           <div className="form-section">
-            <div className="formInput">
+          <div className="formInput">
               <input type="submit" value={"Update"} onClick={handleSave} />
-            </div>
+              <InlineError message={error} />
           </div>
-        </form>
-      ) : (
-        <ErrorPage />
-      )}
+        </div>
+      </form>
+      <InlineError message={!line && error} />
     </PageContainer>
   );
 }

--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -7,7 +7,7 @@ import { postProfessors, getProfessorById, putProfessorById } from "../../api/pr
 import { postStudents, getStudentById, putStudentById } from "../../api/student_service";
 import { postResearchers, getResearcherById, putResearcherById } from "../../api/researcher_service";
 import BackButton from "../../components/BackButton";
-import ErrorPage from "../../components/error/Error";
+import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
 import { AREA_ENUM, INSTITUTION_TYPE_ENUM, STATUS_ENUM, SCHOLARSHIP_TYPE, GENDER_ENUM } from "../../enum_helpers";
 import MultiSelect from "../../components/Multiselect";
@@ -270,7 +270,6 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
 
     return (
         <PageContainer name={name} isLoading={isLoading}>
-            {!error && (
                 <>
                     <BackButton />
                     <form className="form">
@@ -431,12 +430,11 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                         <div className="form-section">
                             <div className="formInput">
                                 <input type="submit" value={isUpdate ? "Update" : "Submit"} onClick={(e) => handleSave(e)} />
+                                <InlineError message={errorMessage} />
                             </div>
                         </div>
                     </form>
                 </>
-            )}
-            {error && <ErrorPage errorMessage={errorMessage} />}
         </PageContainer>
     );
 }


### PR DESCRIPTION
## Summary
- display inline form errors across all pages instead of redirecting

## Testing
- `npm test --prefix front` *(fails: react-scripts not found)*
- `dotnet test backend/tests/Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a77a23f1483319de17f5e175ee339