### PR TITLE
Improve dissertation forms

### DIFF
--- a/front/src/pages/research/createResearch.jsx
+++ b/front/src/pages/research/createResearch.jsx
@@ -107,6 +107,14 @@ export default function ResearchForm() {
                   <label htmlFor="name">Nome</label>
                   <input type="text" name="name" value={research.dissertation} onChange={(e) => setResearch({...research, dissertation: e.target.value })} id="name" />
               </div>
+              <div className="formInput">
+                  <label htmlFor="project">Projeto</label>
+                  <input type="text" name="project" id="project" value={project?.name || ''} disabled />
+              </div>
+              <div className="formInput">
+                  <label htmlFor="student">Estudante</label>
+                  <input type="text" name="student" id="student" value={`${student?.firstName ?? ''} ${student?.lastName ?? ''}`} disabled />
+              </div>
           </div>
           <div className="form-section">
             <Select

--- a/front/src/pages/research/researchList.jsx
+++ b/front/src/pages/research/researchList.jsx
@@ -44,6 +44,7 @@ export default function ResearchList() {
           mapped = result.map((research) => {
             return {
               Id: research.id,
+              Projeto: research.project?.name,
               Nome: research.dissertation,
               Orientador: `${research.professor?.firstName} ${research.professor?.lastName}`,
               Coorientador: research.coorientator ? `${research.coorientator?.firstName} ${research.coorientator?.lastName}` : '',

--- a/front/src/pages/research/updateResearch.jsx
+++ b/front/src/pages/research/updateResearch.jsx
@@ -21,6 +21,8 @@ export default function ResearchUpdate() {
   const [professorOptions, setProfessorOptions] = useState([]);
   const [coorientatorOptions, setCoorientatorOptions] = useState([]);
   const [research, setResearch] = useState({});
+  const [project, setProject] = useState();
+  const [student, setStudent] = useState();
 
   const setCoorientator = (id) => {
     setResearch({ ...research, coorientatorId: id });
@@ -43,6 +45,8 @@ export default function ResearchUpdate() {
           coorientatorId: data.coorientator?.id,
         });
         const project = await getProjectById(data.project.id);
+        setProject(project);
+        setStudent(data.student);
         const profOpts = project.professors?.map((p) => ({
           value: p.id,
           label: `${p.firstName} ${p.lastName}`,
@@ -99,6 +103,14 @@ export default function ResearchUpdate() {
               <div className="formInput">
                   <label htmlFor="name">Nome</label>
                   <input type="text" name="name" value={research.dissertation||''} onChange={(e) => setResearch({...research, dissertation: e.target.value })} id="name" />
+              </div>
+              <div className="formInput">
+                  <label htmlFor="project">Projeto</label>
+                  <input type="text" name="project" id="project" value={project?.name || ''} disabled />
+              </div>
+              <div className="formInput">
+                  <label htmlFor="student">Estudante</label>
+                  <input type="text" name="student" id="student" value={`${student?.firstName ?? ''} ${student?.lastName ?? ''}`} disabled />
               </div>
           </div>
           <div className="form-section">


### PR DESCRIPTION
## Summary
- show associated project name when creating or updating a dissertation
- list the project column in the dissertations table
- display the student in dissertation forms for clarity

## Testing
- `npm --prefix front test` *(fails: react-scripts not found)*
- `dotnet test backend/tests/Tests.csproj` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fe178ab08331981e9c3a6a2d8ea9