### PR TITLE
Add default admin user creation

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -95,7 +95,10 @@ builder.Services.AddHangfire(configuration => configuration
 
 var app = builder.Build();
 
+// Seed demo data when running locally
 DataSeeder.SeedDatabase(app.Services);
+// Ensure a default administrator exists when no users are present
+DataSeeder.EnsureAdministrator(app.Services);
 
 app.UsePathBase("/api");
 app.UseSwagger();


### PR DESCRIPTION
## Summary
- create an EnsureAdministrator method to seed a default admin user
- call the method on startup

## Testing
- `dotnet test backend/tests/Tests.csproj -c Release`
- `CI=true npm test` *(fails: Jest config issues)*

------
https://chatgpt.com/codex/tasks/task_e_686b0214b79c833195e30660d35558cd