### PR TITLE
Fix layout spacing and add about/contact info

### DIFF
--- a/front/src/pages/changePassword.jsx
+++ b/front/src/pages/changePassword.jsx
@@ -10,7 +10,14 @@ export default function ResetPassword() {
   const [password, setPassword] = useState('');
   const [repeatPassword, setRepeatPassword] = useState('');
   const [error, setError] = useState(undefined);
+  const [isAboutOpen, setIsAboutOpen] = useState(false);
+  const [isContactOpen, setIsContactOpen] = useState(false);
   const token = new URLSearchParams(location.search).get('token');
+
+  const openAbout = () => setIsAboutOpen(true);
+  const openContact = () => setIsContactOpen(true);
+  const closeAbout = () => setIsAboutOpen(false);
+  const closeContact = () => setIsContactOpen(false);
 
   useEffect(() => {
     // Redirect to login if token is not provided in the URL
@@ -53,8 +60,8 @@ export default function ResetPassword() {
           <div className={'header'}>
             <div className="app-name">SAGA</div>
             <div className={'headerOptions'}>
-              <div style={{ marginRight: '2rem' }}>Sobre</div>
-              <div>Contato</div>
+              <div style={{ marginRight: '2rem', cursor: 'pointer' }} onClick={openAbout}>Sobre</div>
+              <div style={{ cursor: 'pointer' }} onClick={openContact}>Contato</div>
             </div>
           </div>
           <div className={'form'}>
@@ -83,6 +90,28 @@ export default function ResetPassword() {
           </div>
         </div>
       </main>
+
+      {isAboutOpen && (
+        <main className="modal">
+          <div className="modal">
+            <div className="modal-content">
+              <span className="close" onClick={closeAbout}>&times;</span>
+              <p>Sistema de Acompanhamento e Gestão Acadêmica.</p>
+            </div>
+          </div>
+        </main>
+      )}
+
+      {isContactOpen && (
+        <main className="modal">
+          <div className="modal">
+            <div className="modal-content">
+              <span className="close" onClick={closeContact}>&times;</span>
+              <p>Para mais informações envie e-mail para ppcic_saga@cefet-rj.br.</p>
+            </div>
+          </div>
+        </main>
+      )}
     </>
   );
 }

--- a/front/src/pages/login.jsx
+++ b/front/src/pages/login.jsx
@@ -15,6 +15,8 @@ export default function Login() {
   const [errorModal, setErrorModal] = useState(undefined);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isAboutOpen, setIsAboutOpen] = useState(false);
+  const [isContactOpen, setIsContactOpen] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -54,6 +56,11 @@ export default function Login() {
     setErrorModal(undefined);
   };
 
+  const openAbout = () => setIsAboutOpen(true);
+  const openContact = () => setIsContactOpen(true);
+  const closeAbout = () => setIsAboutOpen(false);
+  const closeContact = () => setIsContactOpen(false);
+
   const handleResetPassword = async (e) => {
     e.preventDefault();
     setIsSubmitted(true);
@@ -79,8 +86,8 @@ export default function Login() {
               <div className="app-name">SAGA</div>
             </div>
             <div className={'headerOptions'}>
-              <div style={{ marginRight: '2rem' }}>Sobre</div>
-              <div>Contato</div>
+              <div style={{ marginRight: '2rem', cursor: 'pointer' }} onClick={openAbout}>Sobre</div>
+              <div style={{ cursor: 'pointer' }} onClick={openContact}>Contato</div>
             </div>
           </div>
           <div className={'intro'}>
@@ -145,6 +152,28 @@ export default function Login() {
                   <InlineError message={errorModal} />
                 </>
               )}
+            </div>
+          </div>
+        </main>
+      )}
+
+      {isAboutOpen && (
+        <main className="modal">
+          <div className="modal">
+            <div className="modal-content">
+              <span className="close" onClick={closeAbout}>&times;</span>
+              <p>Sistema de Acompanhamento e Gestão Acadêmica.</p>
+            </div>
+          </div>
+        </main>
+      )}
+
+      {isContactOpen && (
+        <main className="modal">
+          <div className="modal">
+            <div className="modal-content">
+              <span className="close" onClick={closeContact}>&times;</span>
+              <p>Para mais informações envie e-mail para ppcic_saga@cefet-rj.br.</p>
             </div>
           </div>
         </main>

--- a/front/src/styles/header.scss
+++ b/front/src/styles/header.scss
@@ -18,6 +18,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
     .logout-button {
         cursor: pointer;
         background: $primary-color;

--- a/front/src/styles/login.scss
+++ b/front/src/styles/login.scss
@@ -23,6 +23,8 @@
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
+        gap: 1rem;
+        margin-left: 1rem;
     }
 
     .body{

--- a/front/src/styles/pageContainer.scss
+++ b/front/src/styles/pageContainer.scss
@@ -5,6 +5,7 @@
     .main {
         flex: 1;
         display: flex;
+        margin-left: 0;
     }
 
     .body {
@@ -26,6 +27,12 @@
 @media (max-width: 768px) {
     .container {
         flex-direction: column;
+    }
+}
+
+@media (min-width: 768px) {
+    .main {
+        margin-left: 200px;
     }
 }
 


### PR DESCRIPTION
## Summary
- add spacing for logout button
- adjust login header spacing
- shift main content when sidebar is visible
- show About and Contact info on login and password reset pages

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686b083aad948331a73e8e6756ab8096