### PR TITLE
Fix orientation update logic

### DIFF
--- a/backend/Infrastructure/Validations/OrientationValidator.cs
+++ b/backend/Infrastructure/Validations/OrientationValidator.cs
@@ -49,5 +49,36 @@ namespace saga.Infrastructure.Validations
 
             return (true, "Success.");
         }
+
+        /// <summary>
+        /// Determines whether an orientation can be updated.
+        /// </summary>
+        /// <param name="orientationId">The ID of the orientation being updated.</param>
+        /// <param name="orientationDto">The orientation DTO containing the new data.</param>
+        /// <returns>A tuple indicating whether the update is allowed and a message describing the result.</returns>
+        public async Task<(bool, string)> CanUpdateOrientation(Guid orientationId, OrientationDto orientationDto)
+        {
+            var project = await _repository.Project.GetByIdAsync(orientationDto.ProjectId);
+            var student = await _repository.Student.GetByIdAsync(orientationDto.StudentId);
+
+            if (project == null || student == null)
+            {
+                return (false, "Project or student not found.");
+            }
+
+            var orientations = await _repository.Orientation.GetAllAsync(x => x.StudentId == student.UserId && x.Id != orientationId);
+
+            if (orientations.Any())
+            {
+                return (false, "Student alredy has an orientation.");
+            }
+
+            if (student.ProjectId != project.Id)
+            {
+                return (false, "Student is not associated with the project.");
+            }
+
+            return (true, "Success.");
+        }
     }
 }

--- a/backend/Services/OrientationService.cs
+++ b/backend/Services/OrientationService.cs
@@ -67,7 +67,7 @@ namespace saga.Services
         /// <inheritdoc />
         public async Task<OrientationInfoDto> UpdateOrientationAsync(Guid id, OrientationDto orientationDto)
         {
-            (var isValid, var message) = await _validations.OrientationValidator.CanAddOrientationToProject(orientationDto);
+            (var isValid, var message) = await _validations.OrientationValidator.CanUpdateOrientation(id, orientationDto);
             if (!isValid)
             {
                 throw new ArgumentException(message);

--- a/front/src/components/select.jsx
+++ b/front/src/components/select.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const Select = ({
   options,
@@ -12,6 +12,10 @@ const Select = ({
   defaultValue = "",
 }) => {
   const [selected, setSelected] = useState(defaultValue);
+
+  useEffect(() => {
+    setSelected(defaultValue);
+  }, [defaultValue]);
 
   const handleChange = (event) => {
     const value = event.target.value;

--- a/front/src/pages/research/createResearch.jsx
+++ b/front/src/pages/research/createResearch.jsx
@@ -42,7 +42,12 @@ export default function ResearchForm() {
   };
 
   const handleProjectChange = async (id) => {
-    setResearch({ ...research, projectId: id });
+    setResearch({
+      ...research,
+      projectId: id,
+      professorId: undefined,
+      coorientatorId: undefined,
+    });
     if (!id) {
       setProject(undefined);
       setProfessorOptions([]);

--- a/front/src/pages/research/updateResearch.jsx
+++ b/front/src/pages/research/updateResearch.jsx
@@ -34,7 +34,12 @@ export default function ResearchUpdate() {
   };
 
   const handleProjectChange = async (pid) => {
-    setResearch({ ...research, projectId: pid });
+    setResearch({
+      ...research,
+      projectId: pid,
+      professorId: undefined,
+      coorientatorId: undefined,
+    });
     if (!pid) {
       setProject(undefined);
       setProfessorOptions([]);


### PR DESCRIPTION
## Summary
- add validation for updating orientations so editing no longer fails
- use the new update validation in `OrientationService`
- fix research forms

## Testing
- `npm --prefix front test` *(fails: react-scripts not found)*
- `dotnet test backend/tests/Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b209875248331b2f444e568e3a662