### PR TITLE
Fix project info missing from orientation mapping

### DIFF
--- a/backend/Models/Mapper/OrientationMapper.cs
+++ b/backend/Models/Mapper/OrientationMapper.cs
@@ -71,7 +71,8 @@ namespace saga.Models.Mapper
                 StudentId = self.StudentId,
                 Coorientator = self.Coorientator?.ToUserDto(),
                 Professor = self.Professor?.ToUserDto(),
-                Student = self.Student?.ToUserDto()
+                Student = self.Student?.ToUserDto(),
+                Project = self.Project?.ToInfoDto()
             };
     }
 }


### PR DESCRIPTION
## Summary
- return project details when converting orientation entities to info DTOs

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b292bfaf083319a6c7a1dad5e64b4