### PR TITLE
Fix user update for admin role

### DIFF
--- a/front/src/pages/user/createUser.jsx
+++ b/front/src/pages/user/createUser.jsx
@@ -6,6 +6,7 @@ import { getProjects } from "../../api/project_service";
 import { postProfessors, getProfessorById, putProfessorById } from "../../api/professor_service";
 import { postStudents, getStudentById, putStudentById } from "../../api/student_service";
 import { postResearchers, getResearcherById, putResearcherById } from "../../api/researcher_service";
+import { getUserById, putUser } from "../../api/user_service";
 import BackButton from "../../components/BackButton";
 import InlineError from "../../components/error/InlineError";
 import PageContainer from "../../components/PageContainer";
@@ -110,6 +111,16 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                     .then(researcher => {
                         setUser(researcher);
                         setProfessor(researcher);
+                    })
+                    .catch(error => {
+                        setError(true);
+                        setErrorMessage(error.message);
+                    });
+            }
+            else if (userType === 'Administrator') {
+                getUserById(id)
+                    .then(admin => {
+                        setUser(admin);
                     })
                     .catch(error => {
                         setError(true);
@@ -260,11 +271,17 @@ export default function UserForm({ type = undefined, isUpdate = false }) {
                 .then((student) => navigate("/professors"))
                 .catch(error => setError(true));
         }
-        else {
+        else if (userType === 'Externo') {
             let body = { ...user, ...professor };
             putResearcherById(id, body)
-                .then((student) => navigate("/researchers"))
+                .then(() => navigate("/researchers"))
                 .catch(error => setError(true));
+        }
+        else if (userType === 'Administrator') {
+            let body = { ...user };
+            putUser(id, body)
+                .then(() => navigate("/users"))
+                .catch(() => setError(true));
         }
     };
 

--- a/front/src/pages/user/userUpdate.jsx
+++ b/front/src/pages/user/userUpdate.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import UserForm from './createUser';
+// map every backend role name to the values expected by UserForm
+const ROLE_MAP = {
+    Student: 'Estudante',
+    Professor: 'Professor',
+    Administrator: 'Administrator',
+    ExternalResearcher: 'Externo',
+    ResetPassword: 'ResetPassword'
+};
 
 export default function UserUpdate(){
     const { role } = useParams();
-    return <UserForm isUpdate={true} type={role} />;
+    const formRole = ROLE_MAP[role] ?? role;
+    return <UserForm isUpdate={true} type={formRole} />;
 }


### PR DESCRIPTION
## Summary
- map backend role names before rendering the user update form
- support fetching/updating Administrator via generic user endpoints
- map every role to ensure the correct form type

## Testing
- `npm --prefix front test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d1e33848331a1d105ef68b3657f