### PR TITLE
Implement backend pagination support

### DIFF
--- a/backend/Controllers/StudentController.cs
+++ b/backend/Controllers/StudentController.cs
@@ -127,12 +127,12 @@ namespace saga.Controllers
 
         [HttpGet]
         [Authorize(Roles = "Administrator, Professor, Student")]
-        [ProducesResponseType(typeof(IEnumerable<StudentInfoDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<IEnumerable<StudentInfoDto>>> GetAllStudentsAsync()
+        [ProducesResponseType(typeof(PagedResult<StudentInfoDto>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<PagedResult<StudentInfoDto>>> GetAllStudentsAsync([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
         {
             try
             {
-                var studentDtos = await _studentService.GetAllStudentsAsync();
+                var studentDtos = await _studentService.GetStudentsPagedAsync(page, pageSize);
                 return Ok(studentDtos);
             }
             catch (Exception ex)

--- a/backend/Infrastructure/Repositories/BaseRepository.cs
+++ b/backend/Infrastructure/Repositories/BaseRepository.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using saga.Infrastructure.Extensions;
 using saga.Models.Entities;
+using saga.Models.DTOs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -95,30 +96,49 @@ namespace saga.Infrastructure.Repositories
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<TEntity>> GetPagedAsync(
+        public async Task<PagedResult<TEntity>> GetPagedAsync(
             Expression<Func<TEntity, bool>> predicate,
             int pageNumber,
             int pageSize,
             params Expression<Func<TEntity, object>>[] includeProperties)
         {
-            return await _dbSet
+            var query = _dbSet
                 .Where(e => !e.IsDeleted)
                 .IncludeMultiple(includeProperties)
-                .Where(predicate).Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToListAsync();
-        }
+                .Where(predicate);
 
-        /// <inheritdoc />
-        public virtual async Task<IEnumerable<TEntity>> GetPagedAsync(
-            int pageNumber,
-            int pageSize)
-        {
-            return await _dbSet
-                .Where(e => !e.IsDeleted)
+            var total = await query.CountAsync();
+            var items = await query
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync();
+
+            return new PagedResult<TEntity>
+            {
+                Items = items,
+                TotalCount = total
+            };
+        }
+
+        /// <inheritdoc />
+        public virtual async Task<PagedResult<TEntity>> GetPagedAsync(
+            int pageNumber,
+            int pageSize)
+        {
+            var query = _dbSet
+                .Where(e => !e.IsDeleted);
+
+            var total = await query.CountAsync();
+            var items = await query
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return new PagedResult<TEntity>
+            {
+                Items = items,
+                TotalCount = total
+            };
         }
 
         /// <inheritdoc />
@@ -132,17 +152,26 @@ namespace saga.Infrastructure.Repositories
         }
 
         /// <inheritdoc />
-        public virtual async Task<IEnumerable<TEntity>> GetPagedAsync(
+        public virtual async Task<PagedResult<TEntity>> GetPagedAsync(
             int pageNumber,
             int pageSize,
             Expression<Func<TEntity, bool>> predicate)
         {
-            return await _dbSet
+            var query = _dbSet
                 .Where(e => !e.IsDeleted)
-                .Include(predicate)
+                .Where(predicate);
+
+            var total = await query.CountAsync();
+            var items = await query
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync();
+
+            return new PagedResult<TEntity>
+            {
+                Items = items,
+                TotalCount = total
+            };
         }
 
         /// <inheritdoc />

--- a/backend/Infrastructure/Repositories/IBaseRepository.cs
+++ b/backend/Infrastructure/Repositories/IBaseRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using saga.Models.Entities;
+using saga.Models.DTOs;
 
 namespace saga.Infrastructure.Repositories
 {
@@ -53,7 +54,11 @@ namespace saga.Infrastructure.Repositories
         /// <param name="pageSize">The maximum number of entities per page.</param>
         /// <param name="includeProperties">An array of property expressions to include in the query results.</param>
         /// <returns>An enumerable collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        Task<IEnumerable<TEntity>> GetPagedAsync(Expression<Func<TEntity, bool>> predicate, int pageNumber, int pageSize, params Expression<Func<TEntity, object>>[] includeProperties);
+        Task<PagedResult<TEntity>> GetPagedAsync(
+            Expression<Func<TEntity, bool>> predicate,
+            int pageNumber,
+            int pageSize,
+            params Expression<Func<TEntity, object>>[] includeProperties);
 
         /// <summary>
         /// Gets a paged collection of entities.
@@ -61,7 +66,7 @@ namespace saga.Infrastructure.Repositories
         /// <param name="pageNumber">The page number to retrieve.</param>
         /// <param name="pageSize">The number of entities to retrieve per page.</param>
         /// <returns>A paged collection of entities.</returns>
-        Task<IEnumerable<TEntity>> GetPagedAsync(int pageNumber, int pageSize);
+        Task<PagedResult<TEntity>> GetPagedAsync(int pageNumber, int pageSize);
 
         /// <summary>
         /// Finds entities that match the specified predicate.
@@ -77,7 +82,10 @@ namespace saga.Infrastructure.Repositories
         /// <param name="pageSize">The number of entities to retrieve per page.</param>
         /// <param name="predicate">The predicate to match.</param>
         /// <returns>A paged collection of entities that match the predicate.</returns>
-        Task<IEnumerable<TEntity>> GetPagedAsync(int pageNumber, int pageSize, Expression<Func<TEntity, bool>> predicate);
+        Task<PagedResult<TEntity>> GetPagedAsync(
+            int pageNumber,
+            int pageSize,
+            Expression<Func<TEntity, bool>> predicate);
 
         /// <summary>
         /// Adds an entity to the repository.

--- a/backend/Models/DTOs/PagedResult.cs
+++ b/backend/Models/DTOs/PagedResult.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace saga.Models.DTOs
+{
+    public class PagedResult<T>
+    {
+        public IEnumerable<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+    }
+}

--- a/backend/Services/Interfaces/IStudentService.cs
+++ b/backend/Services/Interfaces/IStudentService.cs
@@ -64,6 +64,14 @@ namespace saga.Services.Interfaces
         Task<IEnumerable<StudentInfoDto>> GetAllStudentsAsync();
 
         /// <summary>
+        /// Gets a paginated list of students.
+        /// </summary>
+        /// <param name="page">Page number.</param>
+        /// <param name="pageSize">Page size.</param>
+        /// <returns>Paged result of students.</returns>
+        Task<PagedResult<StudentInfoDto>> GetStudentsPagedAsync(int page, int pageSize);
+
+        /// <summary>
         /// Generates a CSV containing the selected fields for all students.
         /// </summary>
         /// <param name="fields">Fields to include in the CSV.</param>

--- a/backend/Services/StudentService.cs
+++ b/backend/Services/StudentService.cs
@@ -121,6 +121,17 @@ namespace saga.Services
         }
 
         /// <inheritdoc />
+        public async Task<PagedResult<StudentInfoDto>> GetStudentsPagedAsync(int page, int pageSize)
+        {
+            var result = await _repository.Student.GetPagedAsync(x => true, page, pageSize, s => s.User);
+            return new PagedResult<StudentInfoDto>
+            {
+                Items = result.Items.Select(s => s.ToInfoDto()),
+                TotalCount = result.TotalCount
+            };
+        }
+
+        /// <inheritdoc />
         public async Task<StudentInfoDto> UpdateStudentAsync(Guid id, StudentDto studentDto)
         {
             var existingStudent = await GetExistingStudentAsync(id);

--- a/backend/tests/StudentServiceTests.cs
+++ b/backend/tests/StudentServiceTests.cs
@@ -173,4 +173,41 @@ public class StudentServiceTests : TestBase
         await Assert.ThrowsAsync<ArgumentException>(() => service.CreateStudentAsync(dto));
         userService.Verify(s => s.CreateUserAsync(It.IsAny<UserDto>()), Times.Never);
     }
+
+    [Fact]
+    public async Task GetStudentsPaged()
+    {
+        var user1 = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "p1@example.com",
+            Cpf = "11111111111",
+            Role = RolesEnum.Student,
+            CreatedAt = DateTime.UtcNow
+        });
+        await Repository.Student.AddAsync(new StudentEntity
+        {
+            UserId = user1.Id,
+            Registration = "R1"
+        });
+
+        var user2 = await Repository.User.AddAsync(new UserEntity
+        {
+            Email = "p2@example.com",
+            Cpf = "22222222222",
+            Role = RolesEnum.Student,
+            CreatedAt = DateTime.UtcNow
+        });
+        await Repository.Student.AddAsync(new StudentEntity
+        {
+            UserId = user2.Id,
+            Registration = "R2"
+        });
+
+        var service = new StudentService(Repository, Mock.Of<ILogger<StudentService>>(), Mock.Of<IUserService>(), new Validations(Repository, new Mock<ILogger<UserValidator>>().Object, new DummyUserContext()));
+
+        var page = await service.GetStudentsPagedAsync(1, 1);
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.Single(page.Items);
+    }
 }

--- a/front/src/api/student_service.js
+++ b/front/src/api/student_service.js
@@ -1,7 +1,7 @@
 import api from './_api'
 
-export async function getStudents(){
-    return (await api.get("students"))?.data
+export async function getStudents(page = 1, pageSize = 10){
+    return (await api.get(`students?page=${page}&pageSize=${pageSize}`))?.data
 }
 
 export async function postStudents(data){

--- a/front/src/pages/student/StudentList.jsx
+++ b/front/src/pages/student/StudentList.jsx
@@ -22,6 +22,7 @@ export default function StudentList() {
     const [isLoading, setIsLoading] = useState(true)
     const [students, setStudents] = useState([])
     const [currentPage, setCurrentPage] = useState(1)
+    const [totalCount, setTotalCount] = useState(0)
     const itemsPerPage = 10
 
 
@@ -40,11 +41,12 @@ export default function StudentList() {
     }, [setRole, navigate, role]);
 
     useEffect(() => {
-        getStudents()
+        setIsLoading(true)
+        getStudents(currentPage, itemsPerPage)
             .then(result => {
                 let mapped = []
                 if (result !== null && result !== undefined) {
-                    mapped = result.map((student) => ({
+                    mapped = result.items.map((student) => ({
                         Id: student.id,
                         Nome: `${student.firstName} ${student.lastName}`,
                         Status: translateEnumValue(STATUS_ENUM, student.status),
@@ -53,12 +55,13 @@ export default function StudentList() {
                         "Data de qualificação": formatDate(student.projectQualificationDate),
                         "Data de defesa": formatDate(student.projectDefenceDate),
                     }))
+                    setTotalCount(result.totalCount)
                 }
                 setStudents(mapped)
             })
             .catch(() => { })
             .finally(() => setIsLoading(false))
-    }, [])
+    }, [currentPage])
 
     const handleExport = () => {
         setIsLoading(true)
@@ -108,14 +111,14 @@ export default function StudentList() {
             <p className="info">Para cadastrar uma dissertação ou prorrogação, abra o perfil do estudante clicando em sua linha.</p>
             <Table
                 data={students}
-                page={currentPage}
+                page={1}
                 itemsPerPage={itemsPerPage}
                 useOptions={true}
                 deleteCallback={handleDelete}
                 editCallback={handleEdit}
                 detailsCallback={(id) => navigate(`${id}`)}
             />
-            <Pagination currentPage={currentPage} totalPages={Math.ceil(students.length / itemsPerPage)} onPageChange={setCurrentPage} />
+            <Pagination currentPage={currentPage} totalPages={Math.ceil(totalCount / itemsPerPage)} onPageChange={setCurrentPage} />
         </PageContainer>
     )
 }


### PR DESCRIPTION
## Summary
- create `PagedResult<T>` DTO for paginated data
- update `BaseRepository` and `IBaseRepository` with paged methods returning `PagedResult`
- extend `StudentService` and its interface with `GetStudentsPagedAsync`
- update `StudentController` to return paginated students via query parameters
- add unit test for new pagination method
- integrate frontend list with backend pagination

## Testing
- `dotnet test --no-build --verbosity minimal backend/tests/Tests.csproj` *(fails: `dotnet` not found)*
- `npm test --prefix front --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3d7195a88331b3ebdf66d0d81d68